### PR TITLE
CMakeLists.txt fix for ROS Melodic's catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(spatio_temporal_voxel_layer)
 add_compile_options(-std=c++17)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 find_package(catkin REQUIRED COMPONENTS
   costmap_2d


### PR DESCRIPTION
Under certain configurations, CMAKE_SOURCE_DIR doesn't point to the project directory.
PROJECT_SOURCE_DIR always point to the directory of the last project() command.