### PR TITLE
implementing abstract class for configurable frustum models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ add_library(${PROJECT_NAME}
             src/spatio_temporal_voxel_layer.cpp
             src/spatio_temporal_voxel_grid.cpp
             src/measurement_buffer.cpp
-            src/frustum.cpp
+            src/frustum_models/depth_camera_frustum.cpp
             src/vdb2pc.cpp
 )
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)

--- a/example/constrained_indoor_environment_config.yaml
+++ b/example/constrained_indoor_environment_config.yaml
@@ -38,3 +38,4 @@ rgbd_obstacle_layer:
     vertical_fov_angle: 0.8745  # default 0.7, radians
     horizontal_fov_angle: 1.048 # default 1.04, radians
     decay_acceleration: 15.0    # default 0, 1/s^2. If laser scanner MUST be 0
+    model_type: 0                # default 0, model type for frustum. 0=depth camera, 1=3d lidar like VLP16 or similar

--- a/example/outdoor_environment_config.yaml
+++ b/example/outdoor_environment_config.yaml
@@ -38,3 +38,4 @@ rgbd_obstacle_layer:
     vertical_fov_angle: 0.8745  # default 0.7, radians
     horizontal_fov_angle: 1.048 # default 1.04, radians
     decay_acceleration: 1.0     # default 0, 1/s^2. If laser scanner MUST be 0
+    model_type: 0                # default 0, model type for frustum. 0=depth camera, 1=3d lidar like VLP16 or similar

--- a/example/standard_indoor_environment_config.yaml
+++ b/example/standard_indoor_environment_config.yaml
@@ -38,3 +38,4 @@ rgbd_obstacle_layer:
     vertical_fov_angle: 0.8745  # default 0.7, radians
     horizontal_fov_angle: 1.048 # default 1.04, radians
     decay_acceleration: 5.0     # default 0, 1/s^2. If laser scanner MUST be 0
+    model_type: 0                # default 0, model type for frustum. 0=depth camera, 1=3d lidar like VLP16 or similar

--- a/include/spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp
+++ b/include/spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp
@@ -37,25 +37,11 @@
  *          and associated methods
  *********************************************************************/
 
-#ifndef FRUSTUM_H_
-#define FRUSTUM_H_
+#ifndef DEPTH_FRUSTUM_H_
+#define DEPTH_FRUSTUM_H_
 
-// Eigen
-#include <Eigen/Geometry>
-// STL
-#include <vector>
-#include <cassert>
-// OpenVDB
-#include <openvdb/openvdb.h>
-// msgs
-#include <geometry_msgs/Point.h>
-#include <visualization_msgs/Marker.h>
-#include <visualization_msgs/MarkerArray.h>
-#include <geometry_msgs/Quaternion.h>
-#include <geometry_msgs/PointStamped.h>
-#include <geometry_msgs/Pose.h>
-// ROS
-#include <ros/ros.h>
+// STVL
+#include <spatio_temporal_voxel_layer/frustum_models/frustum.hpp>
 
 namespace geometry
 {
@@ -63,55 +49,23 @@ namespace geometry
 // visualize the frustum should someone other than me care
 #define VISUALIZE_FRUSTUM 0
 
-// A structure for maintaining vectors and points in world spaces
-struct VectorWithPt3D
-{
-  VectorWithPt3D(const double& x_, const double& y_, \
-                 const double& z_, const Eigen::Vector3d& p0) : \
-                 x(x_), y(y_), z(z_), initial_point(p0)
-  {
-  }
-  
-  VectorWithPt3D(void) : x(0.), y(0.), z(0.)
-  {
-  }
-
-  inline VectorWithPt3D operator*(double a)
-  {
-    return VectorWithPt3D(a*x, a*y, a*z, initial_point);
-  }
-
-  // given a transform, transform its information
-  void TransformFrames(const Eigen::Affine3d& homogeneous_transform)
-  {
-    Eigen::Vector3d vec_t = homogeneous_transform.rotation() * Eigen::Vector3d(x,y,z);
-    vec_t.normalize();
-    x = vec_t[0]; y = vec_t[1]; z = vec_t[2];
-    initial_point = homogeneous_transform * initial_point;
-    return;
-  }
-
-  double x, y, z;
-  Eigen::Vector3d initial_point;
-};
-
 // A class to model a depth sensor frustum in world space
-class Frustum
+class DepthCameraFrustum : public Frustum
 {
 public:
-  Frustum(const double& vFOV, const double& hFOV,
+  DepthCameraFrustum(const double& vFOV, const double& hFOV,
           const double& min_dist, const double& max_dist);
-  ~Frustum(void);
+  virtual ~DepthCameraFrustum(void);
 
   // transform plane normals by depth camera pose
-  void TransformPlaneNormals(void);
+  virtual void TransformModel(void);
 
   // determine if a point is inside of the transformed frustum
-  bool IsInside(const openvdb::Vec3d& pt);
+  virtual bool IsInside(const openvdb::Vec3d& pt);
 
   // set pose of depth camera in global space
-  void SetPosition(const geometry_msgs::Point& origin);
-  void SetOrientation(const geometry_msgs::Quaternion& quat);
+  virtual void SetPosition(const geometry_msgs::Point& origin);
+  virtual void SetOrientation(const geometry_msgs::Quaternion& quat);
 
 private:
   // utils to find useful frustum metadata

--- a/include/spatio_temporal_voxel_layer/frustum_models/frustum.hpp
+++ b/include/spatio_temporal_voxel_layer/frustum_models/frustum.hpp
@@ -1,0 +1,119 @@
+/*********************************************************************
+ *
+ * Software License Agreement
+ *
+ *  Copyright (c) 2018, Simbe Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Simbe Robotics, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Steve Macenski (steven.macenski@simberobotics.com)
+ * Purpose: Abstract class for a frustum model implementation
+ *********************************************************************/
+
+#ifndef FRUSTUM_H_
+#define FRUSTUM_H_
+
+// Eigen
+#include <Eigen/Geometry>
+// STL
+#include <vector>
+#include <cassert>
+// OpenVDB
+#include <openvdb/openvdb.h>
+// msgs
+#include <geometry_msgs/Point.h>
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/Pose.h>
+// ROS
+#include <ros/ros.h>
+
+namespace geometry
+{
+
+// A structure for maintaining vectors and points in world spaces
+struct VectorWithPt3D
+{
+  VectorWithPt3D(const double& x_, const double& y_, \
+                 const double& z_, const Eigen::Vector3d& p0) : \
+                 x(x_), y(y_), z(z_), initial_point(p0)
+  {
+  }
+  
+  VectorWithPt3D(void) : x(0.), y(0.), z(0.)
+  {
+  }
+
+  inline VectorWithPt3D operator*(double a)
+  {
+    return VectorWithPt3D(a*x, a*y, a*z, initial_point);
+  }
+
+  // given a transform, transform its information
+  void TransformFrames(const Eigen::Affine3d& homogeneous_transform)
+  {
+    Eigen::Vector3d vec_t = homogeneous_transform.rotation() * Eigen::Vector3d(x,y,z);
+    vec_t.normalize();
+    x = vec_t[0]; y = vec_t[1]; z = vec_t[2];
+    initial_point = homogeneous_transform * initial_point;
+    return;
+  }
+
+  double x, y, z;
+  Eigen::Vector3d initial_point;
+};
+
+// A class to model a depth sensor frustum in world space
+class Frustum
+{
+public:
+  Frustum() {};
+  virtual ~Frustum(void) {};
+
+  // determine if a point is inside of the transformed frustum
+  virtual bool IsInside(const openvdb::Vec3d& pt) = 0;
+
+  // set pose of depth camera in global space
+  virtual void SetPosition(const geometry_msgs::Point& origin) = 0;
+  virtual void SetOrientation(const geometry_msgs::Quaternion& quat) = 0;
+
+  // transform model to the current coordinates
+  virtual void TransformModel(void) = 0;
+
+private:
+  Eigen::Vector3d _position;
+  Eigen::Quaterniond _orientation;
+  bool _valid_frustum;
+};
+
+} // end namespace
+
+#endif

--- a/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -71,26 +71,27 @@ typedef pcl::PointCloud<pcl::PointXYZ>::Ptr point_cloud_ptr;
 class MeasurementBuffer
 {
 public:
-  MeasurementBuffer(const std::string& topic_name,       \
-                    const double& observation_keep_time, \
-                    const double& expected_update_rate,  \
-                    const double& min_obstacle_height,   \
-                    const double& max_obstacle_height,   \
-                    const double& obstacle_range,        \
-                    tf::TransformListener& tf,           \
-                    const std::string& global_frame,     \
-                    const std::string& sensor_frame,     \
-                    const double& tf_tolerance,          \
-                    const double& min_d,                 \
-                    const double& max_d,                 \
-                    const double& vFOV,                  \
-                    const double& hFOV,                  \
-                    const double& decay_acceleration,    \
-                    const bool& marking,                 \
-                    const bool& clearing,                \
-                    const double& voxel_size,            \
-                    const bool& voxel_filter,            \
-                    const bool& clear_buffer_after_reading);
+  MeasurementBuffer(const std::string& topic_name,          \
+                    const double& observation_keep_time,    \
+                    const double& expected_update_rate,     \
+                    const double& min_obstacle_height,      \
+                    const double& max_obstacle_height,      \
+                    const double& obstacle_range,           \
+                    tf::TransformListener& tf,              \
+                    const std::string& global_frame,        \
+                    const std::string& sensor_frame,        \
+                    const double& tf_tolerance,             \
+                    const double& min_d,                    \
+                    const double& max_d,                    \
+                    const double& vFOV,                     \
+                    const double& hFOV,                     \
+                    const double& decay_acceleration,       \
+                    const bool& marking,                    \
+                    const bool& clearing,                   \
+                    const double& voxel_size,               \
+                    const bool& voxel_filter,               \
+                    const bool& clear_buffer_after_reading, \
+                    const ModelType& model_type);
 
   ~MeasurementBuffer(void);
 
@@ -123,6 +124,7 @@ private:
   double _min_z, _max_z, _vertical_fov, _horizontal_fov, _decay_acceleration;
   double _voxel_size;
   bool _marking, _clearing, _voxel_filter, _clear_buffer_after_reading;
+  ModelType _model_type;
 };
 
 } // namespace buffer

--- a/include/spatio_temporal_voxel_layer/measurement_reading.h
+++ b/include/spatio_temporal_voxel_layer/measurement_reading.h
@@ -46,6 +46,11 @@
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Quaternion.h>
 
+enum ModelType
+{
+  DEPTH_CAMERA = 0
+};
+
 namespace observation
 {
 
@@ -61,7 +66,7 @@ struct MeasurementReading
   /*****************************************************************************/
   MeasurementReading(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud, \
             double obstacle_range, double min_z, double max_z, double vFOV, double hFOV,
-            double decay_acceleration, bool marking, bool clearing) :
+            double decay_acceleration, bool marking, bool clearing, ModelType model_type) :
   /*****************************************************************************/
                                       _origin(origin),                                   \
                                       _cloud(new pcl::PointCloud<pcl::PointXYZ>(cloud)), \
@@ -72,15 +77,16 @@ struct MeasurementReading
                                       _horizontal_fov_in_rad(hFOV),                      \
                                       _decay_acceleration(decay_acceleration),           \
                                       _marking(marking),                                 \
-                                      _clearing(clearing)
+                                      _clearing(clearing),                               \
+                                      _model_type(model_type)
   {
   }
 
   /*****************************************************************************/
-  MeasurementReading(pcl::PointCloud<pcl::PointXYZ> cloud, double obstacle_range) :
+  MeasurementReading(pcl::PointCloud<pcl::PointXYZ> cld, double obstacle_range) :
+                               _cloud(new pcl::PointCloud<pcl::PointXYZ>(cld)),
+                               _obstacle_range_in_m(obstacle_range)
   /*****************************************************************************/
-                                    _cloud(new pcl::PointCloud<pcl::PointXYZ>(cloud)), \
-                                    _obstacle_range_in_m(obstacle_range)
   {
   }
 
@@ -97,7 +103,8 @@ struct MeasurementReading
                              _marking(obs._marking),                                    \
                              _clearing(obs._clearing),                                  \
                              _orientation(obs._orientation),                            \
-                             _decay_acceleration(obs._decay_acceleration)
+                             _decay_acceleration(obs._decay_acceleration),              \
+                             _model_type(obs._model_type)
   {
   }
 
@@ -107,6 +114,7 @@ struct MeasurementReading
   double _obstacle_range_in_m, _min_z_in_m, _max_z_in_m;
   double _vertical_fov_in_rad, _horizontal_fov_in_rad;
   double _marking, _clearing, _decay_acceleration;
+  ModelType _model_type;
 
 };
 

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -100,6 +100,13 @@ struct frustum_model
     frustum(_frustum), accel_factor(_factor)
   {
   }
+  ~frustum_model()
+  {
+    if (frustum)
+    {
+      delete frustum;
+    }
+  }
   geometry::Frustum* frustum;
   const double accel_factor;
 };

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -62,7 +62,7 @@
 #include <openvdb/tools/RayIntersector.h>
 // measurement struct and buffer
 #include <spatio_temporal_voxel_layer/measurement_buffer.hpp>
-#include <spatio_temporal_voxel_layer/frustum.hpp>
+#include <spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp>
 // Mutex
 #include <boost/thread/mutex.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
@@ -96,11 +96,11 @@ struct occupany_cell
 // Structure for wrapping frustum model and necessary metadata
 struct frustum_model
 {
-  frustum_model(geometry::Frustum _frustum, const double& _factor) :
+  frustum_model(geometry::Frustum* _frustum, const double& _factor) :
     frustum(_frustum), accel_factor(_factor)
   {
   }
-  geometry::Frustum frustum;
+  geometry::Frustum* frustum;
   const double accel_factor;
 };
 

--- a/src/frustum_models/depth_camera_frustum.cpp
+++ b/src/frustum_models/depth_camera_frustum.cpp
@@ -35,16 +35,15 @@
  * Author: Steve Macenski (steven.macenski@simberobotics.com)
  *********************************************************************/
 
-#include <spatio_temporal_voxel_layer/frustum.hpp>
+#include <spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp>
 
 namespace geometry
 {
 
 /*****************************************************************************/
-Frustum::Frustum(const double& vFOV, const double& hFOV,     \
-                 const double& min_dist, const double& max_dist) :  
-                                   _vFOV(vFOV), _hFOV(hFOV), \
-                                   _min_d(min_dist), _max_d(max_dist)
+DepthCameraFrustum::DepthCameraFrustum(const double& vFOV, const double& hFOV,
+                              const double& min_dist, const double& max_dist) :
+                   _vFOV(vFOV), _hFOV(hFOV), _min_d(min_dist), _max_d(max_dist)
 /*****************************************************************************/
 {
   _valid_frustum = false;
@@ -59,13 +58,13 @@ Frustum::Frustum(const double& vFOV, const double& hFOV,     \
 }
 
 /*****************************************************************************/
-Frustum::~Frustum(void)
+DepthCameraFrustum::~DepthCameraFrustum(void)
 /*****************************************************************************/
 {
 }
 
 /*****************************************************************************/
-void Frustum::ComputePlaneNormals(void)
+void DepthCameraFrustum::ComputePlaneNormals(void)
 /*****************************************************************************/
 {
   // give ability to construct with bogus values
@@ -159,7 +158,7 @@ void Frustum::ComputePlaneNormals(void)
 }
 
 /*****************************************************************************/
-void Frustum::TransformPlaneNormals(void)
+void DepthCameraFrustum::TransformModel(void)
 /*****************************************************************************/
 {
   if (!_valid_frustum)
@@ -290,7 +289,7 @@ void Frustum::TransformPlaneNormals(void)
 }
 
 /*****************************************************************************/
-bool Frustum::IsInside(const openvdb::Vec3d& pt)
+bool DepthCameraFrustum::IsInside(const openvdb::Vec3d& pt)
 /*****************************************************************************/
 {
   if (!_valid_frustum)
@@ -315,21 +314,21 @@ bool Frustum::IsInside(const openvdb::Vec3d& pt)
 }
 
 /*****************************************************************************/
-void Frustum::SetPosition(const geometry_msgs::Point& origin)
+void DepthCameraFrustum::SetPosition(const geometry_msgs::Point& origin)
 /*****************************************************************************/
 {
   _position = Eigen::Vector3d(origin.x, origin.y, origin.z);
 }
 
 /*****************************************************************************/
-void Frustum::SetOrientation(const geometry_msgs::Quaternion& quat)
+void DepthCameraFrustum::SetOrientation(const geometry_msgs::Quaternion& quat)
 /*****************************************************************************/
 {
   _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z);
 }
 
 /*****************************************************************************/
-double Frustum::Dot(const VectorWithPt3D& plane_pt, \
+double DepthCameraFrustum::Dot(const VectorWithPt3D& plane_pt, \
                                           const openvdb::Vec3d& query_pt) const
 /*****************************************************************************/
 {
@@ -337,7 +336,7 @@ double Frustum::Dot(const VectorWithPt3D& plane_pt, \
 }
 
 /*****************************************************************************/
-double Frustum::Dot(const VectorWithPt3D& plane_pt, \
+double DepthCameraFrustum::Dot(const VectorWithPt3D& plane_pt, \
                                          const Eigen::Vector3d& query_pt) const
 /*****************************************************************************/
 {

--- a/src/measurement_buffer.cpp
+++ b/src/measurement_buffer.cpp
@@ -41,26 +41,27 @@ namespace buffer
 {
 
 /*****************************************************************************/
-MeasurementBuffer::MeasurementBuffer(const std::string& topic_name,       \
-                                     const double& observation_keep_time, \
-                                     const double& expected_update_rate,  \
-                                     const double& min_obstacle_height,   \
-                                     const double& max_obstacle_height,   \
-                                     const double& obstacle_range,        \
-                                     tf::TransformListener& tf,           \
-                                     const std::string& global_frame,     \
-                                     const std::string& sensor_frame,     \
-                                     const double& tf_tolerance,          \
-                                     const double& min_d,                 \
-                                     const double& max_d,                 \
-                                     const double& vFOV,                  \
-                                     const double& hFOV,                  \
-                                     const double& decay_acceleration,    \
-                                     const bool& marking,                 \
-                                     const bool& clearing,                \
-                                     const double& voxel_size,            \
-                                     const bool& voxel_filter,            \
-                                     const bool& clear_buffer_after_reading) :
+MeasurementBuffer::MeasurementBuffer(const std::string& topic_name,          \
+                                     const double& observation_keep_time,    \
+                                     const double& expected_update_rate,     \
+                                     const double& min_obstacle_height,      \
+                                     const double& max_obstacle_height,      \
+                                     const double& obstacle_range,           \
+                                     tf::TransformListener& tf,              \
+                                     const std::string& global_frame,        \
+                                     const std::string& sensor_frame,        \
+                                     const double& tf_tolerance,             \
+                                     const double& min_d,                    \
+                                     const double& max_d,                    \
+                                     const double& vFOV,                     \
+                                     const double& hFOV,                     \
+                                     const double& decay_acceleration,       \
+                                     const bool& marking,                    \
+                                     const bool& clearing,                   \
+                                     const double& voxel_size,               \
+                                     const bool& voxel_filter,               \
+                                     const bool& clear_buffer_after_reading, \
+                                     const ModelType& model_type) :
 /*****************************************************************************/
     _tf(tf), _observation_keep_time(observation_keep_time), 
     _expected_update_rate(expected_update_rate),_last_updated(ros::Time::now()), 
@@ -71,7 +72,8 @@ MeasurementBuffer::MeasurementBuffer(const std::string& topic_name,       \
     _vertical_fov(vFOV), _horizontal_fov(hFOV),
     _decay_acceleration(decay_acceleration), _marking(marking),
     _clearing(clearing), _voxel_size(voxel_size), _voxel_filter(voxel_filter),
-    _clear_buffer_after_reading(clear_buffer_after_reading)
+    _clear_buffer_after_reading(clear_buffer_after_reading),
+    _model_type(model_type)
 {
 }
 
@@ -140,6 +142,7 @@ void MeasurementBuffer::BufferPCLCloud(const \
     _observation_list.front()._decay_acceleration = _decay_acceleration;
     _observation_list.front()._clearing = _clearing;
     _observation_list.front()._marking = _marking;
+    _observation_list.front()._model_type = _model_type;
 
     if (_clearing && !_marking)
     {

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -132,6 +132,7 @@ void SpatioTemporalVoxelGrid::ClearFrustums(const \
     else
     {
       // add else if statement for each implemented model
+      delete frustum;
       continue;
     }
 
@@ -195,7 +196,6 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
           break;
         }
       }
-      delete frustum_it->frustum;
     }
 
     // if not inside any, check against nominal decay model

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -62,7 +62,10 @@ SpatioTemporalVoxelGrid::~SpatioTemporalVoxelGrid(void)
 /*****************************************************************************/
 {
   // pcl pointclouds free themselves
-  delete _cost_map;
+  if (_cost_map)
+  {
+    delete _cost_map;    
+  }
 }
 
 /*****************************************************************************/

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -50,7 +50,10 @@ SpatioTemporalVoxelLayer::~SpatioTemporalVoxelLayer(void)
 /*****************************************************************************/
 {
   // I prefer to manage my own memory, I know others like std::unique_ptr
-  delete _voxel_grid;
+  if (_voxel_grid)
+  {
+    delete _voxel_grid;    
+  }
 }
 
 /*****************************************************************************/
@@ -100,6 +103,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   nh.param("mapping_mode", _mapping_mode, false);
   // if mapping, how often to save a map for safety
   nh.param("map_save_duration", map_save_time, 60.);
+  ROS_INFO("%s loaded parameters from parameter server.", getName().c_str());
 
   if (_mapping_mode)
   {
@@ -129,6 +133,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
                                                         _publish_voxels);
   matchSize();
   current_ = true;
+  ROS_INFO("%s created underlying voxel grid.", getName().c_str());
 
   const std::string tf_prefix = tf::getPrefixParam(prefix_nh);
   std::stringstream ss(topics_string);

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -167,6 +167,10 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     source_node.param("voxel_filter", voxel_filter, false);
     // clears measurement buffer after reading values from it
     source_node.param("clear_after_reading", clear_after_reading, false);
+    // model type - default depth camera frustum model
+    int model_type_int;
+    source_node.param("model_type", model_type_int, 0);
+    ModelType model_type = static_cast<ModelType>(model_type_int);
 
     if (!sensor_frame.empty())
     {
@@ -194,7 +198,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
         obstacle_range, *tf_, _global_frame,                             \
         sensor_frame, transform_tolerance, min_z, max_z, vFOV,           \
         hFOV, decay_acceleration, marking, clearing, _voxel_size,        \
-        voxel_filter, clear_after_reading)));
+        voxel_filter, clear_after_reading, model_type)));
 
     // Add buffer to marking observation buffers
     if (marking == true)


### PR DESCRIPTION
@nickvaras I implemented the abstract class so you can add your frustum model to the package.

As you can see you need to do a couple things:
* Add `THREE_D_LIDAR` OR `VLP16_OR_SIMILAR` to the `ModelType` enum
* implement your class as a derived class of the frustum model
* add an `if else` statement in the iterator loop for processing clearing measurements
* set the `model_type` parameter to 0, 1, etc for what model you like

This PR requires
- [x] testing to make sure nothing broke
- [x] validation of no memory leaks - look at in morning if still running

