### PR TITLE
fix undefined symbol to tf2::getTimestamp(geometry_msgs::PoseStamped)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_ros
   roscpp
   tf2_ros
+  tf2_geometry_msgs
   visualization_msgs
   message_generation
   dynamic_reconfigure
@@ -77,6 +78,7 @@ catkin_package(
         std_msgs
         costmap_2d
         tf2_ros
+        tf2_geometry_msgs
         visualization_msgs
         dynamic_reconfigure
     DEPENDS

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>libopenvdb-dev</build_depend>
@@ -38,6 +39,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>libopenvdb-dev</run_depend>
   <run_depend>libopenvdb</run_depend>

--- a/src/measurement_buffer.cpp
+++ b/src/measurement_buffer.cpp
@@ -36,6 +36,7 @@
  *********************************************************************/
 
 #include <spatio_temporal_voxel_layer/measurement_buffer.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 namespace buffer
 {


### PR DESCRIPTION
Hi,
I had undefined symbol issues to the tf2::getTimestamp(geometry_mgs::PoseStamped). 

This is intrinsically used by the tf2_ros::Buffer::transform, when the function is called with geometry_msgs::PoseStamped as argument. The callee is inside measurement_buffer.cpp

Technically the callee is implemented correctly, and it is rather a design flaw in the tf2_ros::Buffer; However this is a pragmatic fix.

I also included the tf_geometry_msgs dependency, used in the spatio_temporal_voxel_layer.cpp. This package is not inside of the dependencies of tf2_ros, hence must be included explicitly.

Best, 
Dima

// edit, typos