### PR TITLE
dynamic (common) min max obstacle height

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,11 @@ Add this plugin to your costmap params file.
 
 `roslaunch [navigation_pkg] move_base.launch`
 
-### Enabing/disabling observation_sources real-time
+### Dynamically reconfigurable parameters
 
-To enable/disable observation sources use a ros service for each source:
+Several parameters are dynamically reconfigurable.
+
+To enable/disable observation sources at runtime, use a ros service for each source:
 
 ~rgbd_obstacle_layer/$(source_name)/toggle_enabled (std_srvs/SetBool)
   -  request.data = true   // Enable observation source
@@ -171,6 +173,8 @@ To enable/disable observation sources use a ros service for each source:
  rosservice call /move_base/global_costmap/rgbd_obstacle_layer/rgbd_back/toggle_enabled "data: true"
  rosservice call /move_base/local_costmap/rgbd_obstacle_layer/rgbd_back/toggle_enabled "data: false"
  ```
+
+The minimum and maximum obstacle height parameters are set per-observation (see yaml configuration files), but a Dynamic Reconfigure parameter is made available to change these values. Please note that values set this way will apply to all observation sources, so if you need different values for different sources, then this may not be the solution you need. But remember, these minimum and maximum values are used by the built-in PCL Voxel/PassThrough filters, so you always have the option of pre-processing your sensor data separately before feeding it into STVL.
  
 ### Debug and Model Fitting
 

--- a/cfg/SpatioTemporalVoxelLayer.cfg
+++ b/cfg/SpatioTemporalVoxelLayer.cfg
@@ -25,7 +25,7 @@ gen.add("decay_model", int_t, 1, "Decay models", 0, edit_method=decay_model_enum
 gen.add("voxel_decay", double_t, 1, "Seconds if linear, e^n if exponential", 10.0, -1, 200.0)
 gen.add("mapping_mode", bool_t, 0, "Mapping mode", False)
 gen.add("map_save_duration", double_t, 0, "f mapping, how often to save a map for safety", 60.0, 1.0, 2000.0)
-gen.add("general_min_obstacle_height", double_t, 2, "minimum obstacle height in meters. Applies to all observations", 0.0, -50.0, 50.0)
-gen.add("general_max_obstacle_height", double_t, 2, "maximum obstacle height in meters. Applies to all observations", 3.0, -50.0, 50.0)
+gen.add("general_min_obstacle_height", double_t, 2, "Minimum obstacle height in meters. Applies to all observations", 0.0, -50.0, 50.0)
+gen.add("general_max_obstacle_height", double_t, 2, "Maximum obstacle height in meters. Applies to all observations", 3.0, -50.0, 50.0)
 
 exit(gen.generate("spatio_temporal_voxel_layer", "spatio_temporal_voxel_layer", "SpatioTemporalVoxelLayer"))

--- a/cfg/SpatioTemporalVoxelLayer.cfg
+++ b/cfg/SpatioTemporalVoxelLayer.cfg
@@ -25,5 +25,7 @@ gen.add("decay_model", int_t, 1, "Decay models", 0, edit_method=decay_model_enum
 gen.add("voxel_decay", double_t, 1, "Seconds if linear, e^n if exponential", 10.0, -1, 200.0)
 gen.add("mapping_mode", bool_t, 0, "Mapping mode", False)
 gen.add("map_save_duration", double_t, 0, "f mapping, how often to save a map for safety", 60.0, 1.0, 2000.0)
+gen.add("general_min_obstacle_height", double_t, 2, "minimum obstacle height in meters. Applies to all observations", 0.0, -50.0, 50.0)
+gen.add("general_max_obstacle_height", double_t, 2, "maximum obstacle height in meters. Applies to all observations", 3.0, -50.0, 50.0)
 
 exit(gen.generate("spatio_temporal_voxel_layer", "spatio_temporal_voxel_layer", "SpatioTemporalVoxelLayer"))

--- a/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -111,6 +111,8 @@ public:
   // enabler setter getter
   bool IsEnabled(void) const;
   void SetEnabled(const bool& enabled);
+  void SetVerticalLimits(const double& min_obstacle_height,const double& max_obstacle_height);
+
 
   // State knoweldge if sensors are operating as expected
   bool UpdatedAtExpectedRate(void) const;

--- a/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -111,7 +111,7 @@ public:
   // enabler setter getter
   bool IsEnabled(void) const;
   void SetEnabled(const bool& enabled);
-  void SetVerticalLimits(const double& min_obstacle_height,const double& max_obstacle_height);
+  void SetVerticalLimits(const double& min_obstacle_height, const double& max_obstacle_height);
 
 
   // State knoweldge if sensors are operating as expected

--- a/src/measurement_buffer.cpp
+++ b/src/measurement_buffer.cpp
@@ -284,6 +284,16 @@ void MeasurementBuffer::SetEnabled(const bool& enabled)
 }
 
 /*****************************************************************************/
+void MeasurementBuffer::SetVerticalLimits(const double& min_obstacle_height,      \
+                                          const double& max_obstacle_height)
+  
+/*****************************************************************************/
+{
+  _min_obstacle_height = min_obstacle_height;
+  _max_obstacle_height = max_obstacle_height;
+}
+
+/*****************************************************************************/
 void MeasurementBuffer::ResetLastUpdatedTime(void)
 /*****************************************************************************/
 {

--- a/src/measurement_buffer.cpp
+++ b/src/measurement_buffer.cpp
@@ -284,7 +284,7 @@ void MeasurementBuffer::SetEnabled(const bool& enabled)
 }
 
 /*****************************************************************************/
-void MeasurementBuffer::SetVerticalLimits(const double& min_obstacle_height,      \
+void MeasurementBuffer::SetVerticalLimits(const double& min_obstacle_height,  \
                                           const double& max_obstacle_height)
   
 /*****************************************************************************/

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -597,7 +597,7 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
   _mapping_mode = config.mapping_mode;
   _map_save_duration = ros::Duration(config.map_save_duration);
 
-  if (level >=1) //update grid
+  if (level > 0) //update grid
   {
     auto default_value = (config.track_unknown_space) ? \
                             costmap_2d::NO_INFORMATION : costmap_2d::FREE_SPACE;
@@ -611,6 +611,15 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
     _voxel_grid = new volume_grid::SpatioTemporalVoxelGrid(_voxel_size, \
       static_cast<double>(default_value_), _decay_model, \
       _voxel_decay, _publish_voxels);
+  }
+
+  if (level >1) //Override all observations' vertical range with these common parameters
+  {
+    observation_buffers_iter it = _observation_buffers.begin();
+    for (it; it != _observation_buffers.end(); ++it)
+    {
+      (*it)->SetVerticalLimits(config.general_min_obstacle_height,config.general_max_obstacle_height);
+    }
   }
 }
 

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -613,12 +613,12 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
       _voxel_decay, _publish_voxels);
   }
 
-  if (level >1) //Override all observations' vertical range with these common parameters
+  if (level > 1) //Override all observations' vertical range with these common parameters
   {
     observation_buffers_iter it = _observation_buffers.begin();
     for (it; it != _observation_buffers.end(); ++it)
     {
-      (*it)->SetVerticalLimits(config.general_min_obstacle_height,config.general_max_obstacle_height);
+      (*it)->SetVerticalLimits(config.general_min_obstacle_height, config.general_max_obstacle_height);
     }
   }
 }


### PR DESCRIPTION
Hi Steve. Congrats by the way on your Best ROS developer nomination. Well deserved.

I'm not sure what to make of this PR. In a way I'm not even sure that it should be merged, but it is certainly meant to spark conversation. It has to do with the ability to dynamically adjust the minimum and maximum obstacle height. The case for those parameters being reconfigurable is, I hope, obvious. There's tons of robots that have some sort means of adjusting height (think mobile manipulators), and conceptually, the fact that we animals can duck under things to not bump into things should make it conceptually evident. 

I do, however, wonder if having the pcl filters built in is backfiring in a way. I get the "batteries included" approach, but at the same time, a nodelet implementation of a voxel or passthorugh filter with zero-copy may be more efficient and is probably in place in most robots anyway, so the benefit of having it built into stvl debatable. Maybe a better PR should be adding the option to skip any pcl filtering altogether for those who want to do it on their own. 

The main issue with this PR is that the added parameter applies to all observation sources. For many robots that have 1 source per layer instance , this may work just fine, but conceptually I don't like the value overriding and ideally each observation source would have its own dynparam server, as we cannot know a-priori the sources so implementing per-source reconfigurable parameters is not trivial (not even know if possible).

node and nodelet implementations of the pcl filters are already dynamically reconfigurable, hence the hesitation here. But, as said, the idea is to at least spark conversation.