### PR TITLE
Adding min_age_outside_frustrum parameter (solving the noisy edge problem)

### DIFF
--- a/cfg/SpatioTemporalVoxelLayer.cfg
+++ b/cfg/SpatioTemporalVoxelLayer.cfg
@@ -22,6 +22,7 @@ gen.add("mark_threshold", double_t, 0, "Over this threshold, the measurement wil
 gen.add("update_footprint_enabled", bool_t, 0, "Cleans where the robot's footprint is", True)
 gen.add("track_unknown_space", bool_t, 1, "If true, marks will be UNKNOWN (255) otherwise, FREE (0)", True)
 gen.add("decay_model", int_t, 1, "Decay models", 0, edit_method=decay_model_enum)
+gen.add("outside_duration_threshold", double_t, 1, "Seconds", 0.0, 0.0, 1.0)
 gen.add("voxel_decay", double_t, 1, "Seconds if linear, e^n if exponential", 10.0, -1, 200.0)
 gen.add("mapping_mode", bool_t, 0, "Mapping mode", False)
 gen.add("map_save_duration", double_t, 0, "f mapping, how often to save a map for safety", 60.0, 1.0, 2000.0)

--- a/cfg/SpatioTemporalVoxelLayer.cfg
+++ b/cfg/SpatioTemporalVoxelLayer.cfg
@@ -22,7 +22,7 @@ gen.add("mark_threshold", double_t, 0, "Over this threshold, the measurement wil
 gen.add("update_footprint_enabled", bool_t, 0, "Cleans where the robot's footprint is", True)
 gen.add("track_unknown_space", bool_t, 1, "If true, marks will be UNKNOWN (255) otherwise, FREE (0)", True)
 gen.add("decay_model", int_t, 1, "Decay models", 0, edit_method=decay_model_enum)
-gen.add("outside_duration_threshold", double_t, 1, "Seconds", 0.0, 0.0, 1.0)
+gen.add("min_age_outside_frustrum", double_t, 1, "the minimum age that a voxel should have to be allow to live outside frustrum", 0.0, 0.0, 1.0)
 gen.add("voxel_decay", double_t, 1, "Seconds if linear, e^n if exponential", 10.0, -1, 200.0)
 gen.add("mapping_mode", bool_t, 0, "Mapping mode", False)
 gen.add("map_save_duration", double_t, 0, "f mapping, how often to save a map for safety", 60.0, 1.0, 2000.0)

--- a/cfg/SpatioTemporalVoxelLayer.cfg
+++ b/cfg/SpatioTemporalVoxelLayer.cfg
@@ -22,7 +22,7 @@ gen.add("mark_threshold", double_t, 0, "Over this threshold, the measurement wil
 gen.add("update_footprint_enabled", bool_t, 0, "Cleans where the robot's footprint is", True)
 gen.add("track_unknown_space", bool_t, 1, "If true, marks will be UNKNOWN (255) otherwise, FREE (0)", True)
 gen.add("decay_model", int_t, 1, "Decay models", 0, edit_method=decay_model_enum)
-gen.add("min_age_outside_frustrum", double_t, 1, "the minimum age that a voxel should have to be allow to live outside frustrum", 0.0, 0.0, 1.0)
+gen.add("min_age_outside_frustrum", double_t, 1, "the minimum age that a voxel should have to be allow to live outside frustrums", 0.0, 0.0, 100.0)
 gen.add("voxel_decay", double_t, 1, "Seconds if linear, e^n if exponential", 10.0, -1, 200.0)
 gen.add("mapping_mode", bool_t, 0, "Mapping mode", False)
 gen.add("map_save_duration", double_t, 0, "f mapping, how often to save a map for safety", 60.0, 1.0, 2000.0)

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -124,7 +124,7 @@ public:
   typedef openvdb::math::Ray<openvdb::Real>::Vec3T Vec3Type;
 
   SpatioTemporalVoxelGrid(const float& voxel_size, const double& background_value,
-                          const int& decay_model, const double& outside_duration_threshold, const double& voxel_decay,
+                          const int& decay_model, const double& min_age_outside_frustrum, const double& voxel_decay,
                           const bool& pub_voxels);
   ~SpatioTemporalVoxelGrid(void);
 
@@ -169,7 +169,7 @@ protected:
 
   mutable openvdb::DoubleGrid::Ptr _grid;
   int                             _decay_model;
-  double                          _background_value, _voxel_size, _outside_duration_threshold, _voxel_decay;
+  double                          _background_value, _voxel_size, _min_age_outside_frustrum, _voxel_decay;
   bool                            _pub_voxels;
   std::vector<geometry_msgs::Point32>*   _grid_points;
   std::unordered_map<occupany_cell, uint>* _cost_map;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -124,7 +124,7 @@ public:
   typedef openvdb::math::Ray<openvdb::Real>::Vec3T Vec3Type;
 
   SpatioTemporalVoxelGrid(const float& voxel_size, const double& background_value,
-                          const int& decay_model, const double& voxel_decay,
+                          const int& decay_model, const double& outside_duration_threshold, const double& voxel_decay,
                           const bool& pub_voxels);
   ~SpatioTemporalVoxelGrid(void);
 
@@ -169,7 +169,7 @@ protected:
 
   mutable openvdb::DoubleGrid::Ptr _grid;
   int                             _decay_model;
-  double                          _background_value, _voxel_size, _voxel_decay;
+  double                          _background_value, _voxel_size, _outside_duration_threshold, _voxel_decay;
   bool                            _pub_voxels;
   std::vector<geometry_msgs::Point32>*   _grid_points;
   std::unordered_map<occupany_cell, uint>* _cost_map;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -161,7 +161,7 @@ private:
   ros::Duration                        _map_save_duration;
   ros::Time                            _last_map_save_time;
   std::string                          _global_frame;
-  double                               _voxel_size, _voxel_decay;
+  double                               _voxel_size, _outside_duration_threshold, _voxel_decay;
   int                                  _combination_method, _mark_threshold;
   volume_grid::GlobalDecayModel        _decay_model;
   bool                                 _update_footprint_enabled, _enabled;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -161,7 +161,7 @@ private:
   ros::Duration                        _map_save_duration;
   ros::Time                            _last_map_save_time;
   std::string                          _global_frame;
-  double                               _voxel_size, _outside_duration_threshold, _voxel_decay;
+  double                               _voxel_size, _min_age_outside_frustrum, _voxel_decay;
   int                                  _combination_method, _mark_threshold;
   volume_grid::GlobalDecayModel        _decay_model;
   bool                                 _update_footprint_enabled, _enabled;

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -43,12 +43,12 @@ namespace volume_grid
 /*****************************************************************************/
 SpatioTemporalVoxelGrid::SpatioTemporalVoxelGrid(const float& voxel_size, \
                    const double& background_value, const int& decay_model,\
-                   const double& outside_duration_threshold,              \
+                   const double& min_age_outside_frustrum,              \
                    const double& voxel_decay, const bool& pub_voxels) :
                    _background_value(background_value),                   \
                    _voxel_size(voxel_size),                               \
                    _decay_model(decay_model),                             \
-                   _outside_duration_threshold(outside_duration_threshold), \
+                   _min_age_outside_frustrum(min_age_outside_frustrum), \
                    _voxel_decay(voxel_decay),                             \
                    _pub_voxels(pub_voxels),                               \
                    _grid_points(new std::vector<geometry_msgs::Point32>),   \
@@ -222,13 +222,15 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
       }
     }
 
-    // if not inside any, check against nominal decay model, also if
-    // too young, it means that it was marked without being in a frustrum
+    // if not inside any, check against nominal decay model, also clearing if
+    // too young.
+    // Depending on min_age_outside_frustrum value and cycle frequency,
+    // a voxel too young  means that it was marked without being in a frustrum
     // (or, edgy case, the point that marked the voxel was in a frustrum
     // but the center of that voxel was not), in that case : clearing
     if(!frustum_cycle)
     {
-      if (base_duration_to_decay < 0. || time_since_marking < _outside_duration_threshold)
+      if (base_duration_to_decay < 0. || time_since_marking < _min_age_outside_frustrum)
       {
         // expired by temporal clearing
         if(!this->ClearGridPoint(pt_index))

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -99,6 +99,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
                                   layered_costmap_->isTrackingUnknown());
   nh.param("decay_model", decay_model_int, 0);
   _decay_model = static_cast<volume_grid::GlobalDecayModel>(decay_model_int);
+  // outside_duration_threshold param
+  nh.param("outside_duration_threshold", _outside_duration_threshold, 0.05);
   // decay param
   nh.param("voxel_decay", _voxel_decay, -1.);
   // whether to map or navigate
@@ -130,6 +132,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   _voxel_grid = new volume_grid::SpatioTemporalVoxelGrid(_voxel_size, \
                                                         (double)default_value_, \
                                                         _decay_model, \
+                                                        _outside_duration_threshold, \
                                                         _voxel_decay, \
                                                         _publish_voxels);
   matchSize();
@@ -620,6 +623,7 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
                             costmap_2d::NO_INFORMATION : costmap_2d::FREE_SPACE;
     default_value_ = default_value;
     _voxel_size = config.voxel_size;
+    _outside_duration_threshold = config.outside_duration_threshold;
     _voxel_decay = config.voxel_decay;
     _decay_model = static_cast<volume_grid::GlobalDecayModel>(config.decay_model);
     _publish_voxels = config.publish_voxel_map;
@@ -627,7 +631,7 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
     delete _voxel_grid;
     _voxel_grid = new volume_grid::SpatioTemporalVoxelGrid(_voxel_size, \
       static_cast<double>(default_value_), _decay_model, \
-      _voxel_decay, _publish_voxels);
+      _outside_duration_threshold, _voxel_decay, _publish_voxels);
   }
 }
 

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -99,8 +99,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
                                   layered_costmap_->isTrackingUnknown());
   nh.param("decay_model", decay_model_int, 0);
   _decay_model = static_cast<volume_grid::GlobalDecayModel>(decay_model_int);
-  // outside_duration_threshold param
-  nh.param("outside_duration_threshold", _outside_duration_threshold, 0.05);
+  // min_age_outside_frustrum param
+  nh.param("min_age_outside_frustrum", _min_age_outside_frustrum, 0.05);
   // decay param
   nh.param("voxel_decay", _voxel_decay, -1.);
   // whether to map or navigate
@@ -132,7 +132,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   _voxel_grid = new volume_grid::SpatioTemporalVoxelGrid(_voxel_size, \
                                                         (double)default_value_, \
                                                         _decay_model, \
-                                                        _outside_duration_threshold, \
+                                                        _min_age_outside_frustrum, \
                                                         _voxel_decay, \
                                                         _publish_voxels);
   matchSize();
@@ -623,7 +623,7 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
                             costmap_2d::NO_INFORMATION : costmap_2d::FREE_SPACE;
     default_value_ = default_value;
     _voxel_size = config.voxel_size;
-    _outside_duration_threshold = config.outside_duration_threshold;
+    _min_age_outside_frustrum = config.min_age_outside_frustrum;
     _voxel_decay = config.voxel_decay;
     _decay_model = static_cast<volume_grid::GlobalDecayModel>(config.decay_model);
     _publish_voxels = config.publish_voxel_map;
@@ -631,7 +631,7 @@ void SpatioTemporalVoxelLayer::DynamicReconfigureCallback( \
     delete _voxel_grid;
     _voxel_grid = new volume_grid::SpatioTemporalVoxelGrid(_voxel_size, \
       static_cast<double>(default_value_), _decay_model, \
-      _outside_duration_threshold, _voxel_decay, _publish_voxels);
+      _min_age_outside_frustrum, _voxel_decay, _publish_voxels);
   }
 }
 


### PR DESCRIPTION
This PR adds the `min_age_outside_frustrum` parameter. I am open to discussion and debate about it (and also about the name of the parameter which I am not super happy with).

The original goal was to solve the noisy frustrum edges problem (see for instance https://github.com/SteveMacenski/spatio_temporal_voxel_layer/issues/141). The bigger the size (resolution) of the grid the more this problem appears, even for a perfectly calibrated frustrum.  More precisely, considering a non moving robot, grid voxels will be marked and not cleared under the following conditions:

- The voxel sits on a frustrum edge with its center outside the frustrum (and hence non clearable)
- There is an obstacle point on the part of the voxel that is inside the frustrum (and hence the voxel is marked occupied)

This could be solved by avoiding the marking of grid voxels whose center is not inside any frustrum. However this would need an additional potentially costly `IsInside` test when marking. But STVL being temporal, it is possible to get the same behavior almost for free at the next `TemporalClearAndGenerateCostmap` step where each points are already `IsInside` tested: if outside we simply check their age against the new `min_age_outside_frustrum` param. In other words, if we find a voxel too young outside every frustrum, it means that it was marked without being in a frustrum.

By setting `min_age_outside_frustrum` just above the period of one cycle, we get the desired "don't mark voxels whose center is not part of a frustrum" behavior. 
Bonus: by increasing this parameter we get an additional behavior which could be describe as "don't allow a voxel to stay marked outside my field of view if I did not have it under my sight for at least this amount of time".

