### PR TITLE
fix voxel_decay declared type

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -117,7 +117,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   node->get_parameter(name_ + ".decay_model", decay_model_int);
   _decay_model = static_cast<volume_grid::GlobalDecayModel>(decay_model_int);
   // decay param
-  declareParameter("voxel_decay", rclcpp::ParameterValue(-1));
+  declareParameter("voxel_decay", rclcpp::ParameterValue(-1.0));
   node->get_parameter(name_ + ".voxel_decay", _voxel_decay);
   // whether to map or navigate
   declareParameter("mapping_mode", rclcpp::ParameterValue(false));


### PR DESCRIPTION
With last rolling nightly (I guess https://github.com/ros2/rclcpp/pull/1522) we have the following error at runtime:
```
[controller_server-7] [ERROR] []: Caught exception in callback for transition 10
[controller_server-7] [ERROR] []: Original error: parameter 'stvl_layer.voxel_decay' has invalid type: Wrong parameter type, parameter {stvl_layer.voxel_decay} is of type {integer}, setting it to {double} is not allowed.
```
`voxel_decay` parameter declared type was improperly infered. Fixed