### PR TITLE
fixes #199

### DIFF
--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -48,6 +48,7 @@
 // STL
 #include <math.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <ctime>
 #include <iostream>
 #include <utility>
@@ -131,7 +132,8 @@ public:
   // Core making and clearing functions
   void Mark(const std::vector<observation::MeasurementReading>& marking_observations);
   void operator()(const observation::MeasurementReading& obs) const;
-  void ClearFrustums(const std::vector<observation::MeasurementReading>& clearing_observations);
+  void ClearFrustums(const std::vector<observation::MeasurementReading>& clearing_observations, \
+                     std::unordered_set<occupany_cell>& updated_cells);
 
   // Get the pointcloud of the underlying occupancy grid
   void GetOccupancyPointCloud(sensor_msgs::PointCloud2::Ptr& pc2);
@@ -158,7 +160,8 @@ protected:
   double GetTemporalClearingDuration(const double& time_delta);
   double GetFrustumAcceleration(const double& time_delta, \
                                 const double& acceleration_factor);
-  void TemporalClearAndGenerateCostmap(std::vector<frustum_model>& frustums);
+  void TemporalClearAndGenerateCostmap(std::vector<frustum_model>& frustums, \
+                                       std::unordered_set<occupany_cell>& updated_cells);
 
   // Populate the costmap ROS api and pointcloud with a marked point
   void PopulateCostmapAndPointcloud(const openvdb::Coord& pt);

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -133,7 +133,7 @@ public:
   void Mark(const std::vector<observation::MeasurementReading>& marking_observations);
   void operator()(const observation::MeasurementReading& obs);
   void ClearFrustums(const std::vector<observation::MeasurementReading>& clearing_observations, \
-                     std::unordered_set<occupany_cell>& updated_cells);
+                     std::unordered_set<occupany_cell>& cleared_cells);
 
   // Get the pointcloud of the underlying occupancy grid
   void GetOccupancyPointCloud(sensor_msgs::PointCloud2::Ptr& pc2);
@@ -161,7 +161,7 @@ protected:
   double GetFrustumAcceleration(const double& time_delta, \
                                 const double& acceleration_factor);
   void TemporalClearAndGenerateCostmap(std::vector<frustum_model>& frustums, \
-                                       std::unordered_set<occupany_cell>& updated_cells);
+                                       std::unordered_set<occupany_cell>& cleared_cells);
 
   // Populate the costmap ROS api and pointcloud with a marked point
   void PopulateCostmapAndPointcloud(const openvdb::Coord& pt);

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -131,7 +131,7 @@ public:
 
   // Core making and clearing functions
   void Mark(const std::vector<observation::MeasurementReading>& marking_observations);
-  void operator()(const observation::MeasurementReading& obs) const;
+  void operator()(const observation::MeasurementReading& obs);
   void ClearFrustums(const std::vector<observation::MeasurementReading>& clearing_observations, \
                      std::unordered_set<occupany_cell>& updated_cells);
 
@@ -165,6 +165,7 @@ protected:
 
   // Populate the costmap ROS api and pointcloud with a marked point
   void PopulateCostmapAndPointcloud(const openvdb::Coord& pt);
+  void PopulateCostmapAndPointcloud(const openvdb::Vec3d& pose_world);
 
   // Utilities for tranformation
   openvdb::Vec3d WorldToIndex(const openvdb::Vec3d& coord) const;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -164,8 +164,7 @@ protected:
                                        std::unordered_set<occupany_cell>& cleared_cells);
 
   // Populate the costmap ROS api and pointcloud with a marked point
-  void PopulateCostmapAndPointcloud(const openvdb::Coord& pt, \
-                                    const bool& pub_every_voxel);
+  void PopulateCostmapAndPointcloud(const openvdb::Coord& pt);
 
   // Utilities for tranformation
   openvdb::Vec3d WorldToIndex(const openvdb::Vec3d& coord) const;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -164,8 +164,8 @@ protected:
                                        std::unordered_set<occupany_cell>& cleared_cells);
 
   // Populate the costmap ROS api and pointcloud with a marked point
-  void PopulateCostmapAndPointcloud(const openvdb::Coord& pt);
-  void PopulateCostmapAndPointcloud(const openvdb::Vec3d& pose_world);
+  void PopulateCostmapAndPointcloud(const openvdb::Coord& pt, \
+                                    const bool& pub_every_voxel);
 
   // Utilities for tranformation
   openvdb::Vec3d WorldToIndex(const openvdb::Vec3d& coord) const;

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp
@@ -131,7 +131,7 @@ public:
 
   // Core making and clearing functions
   void Mark(const std::vector<observation::MeasurementReading>& marking_observations);
-  void operator()(const observation::MeasurementReading& obs);
+  void operator()(const observation::MeasurementReading& obs) const;
   void ClearFrustums(const std::vector<observation::MeasurementReading>& clearing_observations, \
                      std::unordered_set<occupany_cell>& cleared_cells);
 

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -115,7 +115,7 @@ public:
 
   // Functions to interact with maps
   void UpdateROSCostmap(double* min_x, double* min_y, double* max_x, double* max_y, \
-                        std::unordered_set<volume_grid::occupany_cell>& updated_cells);
+                        std::unordered_set<volume_grid::occupany_cell>& cleared_cells);
   bool updateFootprint(double robot_x, double robot_y, double robot_yaw, \
                        double* min_x, double* min_y, double* max_x, double* max_y);
   void ResetGrid(void);

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -114,7 +114,8 @@ public:
   void ObservationsResetAfterReading() const;
 
   // Functions to interact with maps
-  void UpdateROSCostmap(double* min_x, double* min_y, double* max_x, double* max_y);
+  void UpdateROSCostmap(double* min_x, double* min_y, double* max_x, double* max_y, \
+                        std::unordered_set<volume_grid::occupany_cell>& updated_cells);
   bool updateFootprint(double robot_x, double robot_y, double robot_yaw, \
                        double* min_x, double* min_y, double* max_x, double* max_y);
   void ResetGrid(void);

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -301,7 +301,7 @@ void SpatioTemporalVoxelGrid::Mark(const \
 
 /*****************************************************************************/
 void SpatioTemporalVoxelGrid::operator()(const \
-                                    observation::MeasurementReading& obs)
+                                    observation::MeasurementReading& obs) const
 /*****************************************************************************/
 {
   if (obs._marking)
@@ -328,10 +328,8 @@ void SpatioTemporalVoxelGrid::operator()(const \
       openvdb::Vec3d mark_grid(this->WorldToIndex( \
                                  openvdb::Vec3d(*iter_x, *iter_y, *iter_z)));
 
-      openvdb::Coord pt_index(mark_grid[0], mark_grid[1], mark_grid[2]);
-      PopulateCostmapAndPointcloud(pt_index);
-      
-      if(!this->MarkGridPoint(pt_index, cur_time))
+      if(!this->MarkGridPoint(openvdb::Coord(mark_grid[0], mark_grid[1], \
+                                             mark_grid[2]), cur_time))
       {
         std::cout << "Failed to mark point." << std::endl;
       }

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -205,7 +205,6 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
         {
           // expired by acceleration
           cleared_point = true;
-          cleared_cells.insert(occupany_cell(pose_world[0], pose_world[1]));
           if(!this->ClearGridPoint(pt_index))
           {
             std::cout << "Failed to clear point." << std::endl;
@@ -231,16 +230,20 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
       {
         // expired by temporal clearing
         cleared_point = true;
-        cleared_cells.insert(occupany_cell(pose_world[0], pose_world[1]));
         if(!this->ClearGridPoint(pt_index))
         {
           std::cout << "Failed to clear point." << std::endl;
         }
       }
     }
-    // if here, we can add to costmap and PC2
-    if (!cleared_point)
+    
+    if (cleared_point)
     {
+      cleared_cells.insert(occupany_cell(pose_world[0], pose_world[1]));
+    }
+    else
+    {
+      // if here, we can add to costmap and PC2
       PopulateCostmapAndPointcloud(pt_index, true);
     }
   }

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -250,27 +250,27 @@ void SpatioTemporalVoxelGrid::PopulateCostmapAndPointcloud(                   \
   // add pt to the pointcloud and costmap
   openvdb::Vec3d pose_world = this->IndexToWorld(pt);
 
-  if (_pub_voxels && pub_every_voxel)
-  {
-    geometry_msgs::Point32 point;
-    point.x = pose_world[0];
-    point.y = pose_world[1];
-    point.z = pose_world[2];
-    _grid_points->push_back(point);
-  }
-
   std::unordered_map<occupany_cell, uint>::iterator cell;
   cell = _cost_map->find(occupany_cell(pose_world[0], pose_world[1]));
   if (cell != _cost_map->end())
   {
     cell->second += 1;
+
+    if (_pub_voxels && pub_every_voxel)
+    {
+      geometry_msgs::Point32 point;
+      point.x = pose_world[0];
+      point.y = pose_world[1];
+      point.z = pose_world[2];
+      _grid_points->push_back(point);
+    }
   }
   else
   {
     _cost_map->insert(std::make_pair( \
                               occupany_cell(pose_world[0], pose_world[1]), 1));
 
-    if (_pub_voxels && !pub_every_voxel)
+    if (_pub_voxels)
     {
       geometry_msgs::Point32 point;
       point.x = pose_world[0];

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -179,6 +179,7 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
 
     std::vector<frustum_model>::iterator frustum_it = frustums.begin();
     bool frustum_cycle = false;
+    bool cleared_point = false;
 
     const double time_since_marking = cur_time - cit_grid.getValue();
     const double base_duration_to_decay = GetTemporalClearingDuration( \
@@ -203,6 +204,7 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
         if (time_until_decay < 0.)
         {
           // expired by acceleration
+          cleared_point = true;
           cleared_cells.insert(occupany_cell(pose_world[0], pose_world[1]));
           if(!this->ClearGridPoint(pt_index))
           {
@@ -228,16 +230,19 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
       if (base_duration_to_decay < 0.)
       {
         // expired by temporal clearing
+        cleared_point = true;
         cleared_cells.insert(occupany_cell(pose_world[0], pose_world[1]));
         if(!this->ClearGridPoint(pt_index))
         {
           std::cout << "Failed to clear point." << std::endl;
         }
-        continue;
       }
     }
     // if here, we can add to costmap and PC2
-    PopulateCostmapAndPointcloud(pt_index, true);
+    if (!cleared_point)
+    {
+      PopulateCostmapAndPointcloud(pt_index, true);
+    }
   }
 }
 

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -684,9 +684,10 @@ void SpatioTemporalVoxelLayer::UpdateROSCostmap( \
     }
   }
 
-  for (const auto& cell: cleared_cells)
+  std::unordered_set<volume_grid::occupany_cell>::iterator cell;
+  for (cell = cleared_cells.begin(); cell != cleared_cells.end(); ++cell)
   {
-    touch(cell.x, cell.y, min_x, min_y, max_x, max_y);
+    touch(cell->x, cell->y, min_x, min_y, max_x, max_y);
   }
 }
 

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -662,24 +662,28 @@ void SpatioTemporalVoxelLayer::updateCosts( \
 }
 
 /*****************************************************************************/
-void SpatioTemporalVoxelLayer::UpdateROSCostmap(double* min_x, double* min_y, \
-                                                double* max_x, double* max_y)
+void SpatioTemporalVoxelLayer::UpdateROSCostmap( \
+                        double* min_x, double* min_y, \
+                        double* max_x, double* max_y, \
+                        std::unordered_set<volume_grid::occupany_cell>& updated_cells)
 /*****************************************************************************/
 {
   // grabs map of occupied cells from grid and adds to costmap_
   Costmap2D::resetMaps();
 
-  std::unordered_map<volume_grid::occupany_cell, uint>::iterator it;
-  for (it = _voxel_grid->GetFlattenedCostmap()->begin();
-       it != _voxel_grid->GetFlattenedCostmap()->end(); ++it)
+  auto cost_map = _voxel_grid->GetFlattenedCostmap();
+
+  for (const auto& cell: updated_cells)
   {
+    auto it = cost_map->find(cell);
     uint map_x, map_y;
-    if ( it->second >= _mark_threshold && \
+    if ( it != cost_map->end() && \
+         it->second >= _mark_threshold && \
          worldToMap(it->first.x, it->first.y, map_x, map_y))
     {
       costmap_[getIndex(map_x, map_y)] = costmap_2d::LETHAL_OBSTACLE;
-      touch(it->first.x, it->first.y, min_x, min_y, max_x, max_y);
     }
+    touch(cell.x, cell.y, min_x, min_y, max_x, max_y);
   }
 }
 
@@ -716,10 +720,13 @@ void SpatioTemporalVoxelLayer::updateBounds( \
   ObservationsResetAfterReading();
   current_ = current;
 
+  // cells that were updated
+  std::unordered_set<volume_grid::occupany_cell> updated_cells;
+
   // navigation mode: clear observations, mapping mode: save maps and publish
   if (!_mapping_mode)
   {
-    _voxel_grid->ClearFrustums(clearing_observations);
+    _voxel_grid->ClearFrustums(clearing_observations, updated_cells);
   }
   else if (ros::Time::now() - _last_map_save_time > _map_save_duration)
   {
@@ -740,7 +747,7 @@ void SpatioTemporalVoxelLayer::updateBounds( \
   _voxel_grid->Mark(marking_observations);
 
   // update the ROS Layered Costmap
-  UpdateROSCostmap(min_x, min_y, max_x, max_y);
+  UpdateROSCostmap(min_x, min_y, max_x, max_y, updated_cells);
 
   // publish point cloud in navigation mode
   if (_publish_voxels && !_mapping_mode)


### PR DESCRIPTION
Implementation of the [suggestion](https://github.com/SteveMacenski/spatio_temporal_voxel_layer/issues/199#issuecomment-816915693) by @SteveMacenski to fix #199:

> The fix I could see would be to touch the cells cleared as they were cleared to resize the bounds

Cells that were cleared are stored in an `unordered_set` and touched when updating the ROS costmap.

Bugs fixed in this PR:

- [x] Cleared cells are not touched, so the corresponding area of the costmap isn't updated. The `cleared_cells` container solves this.
- [x] Cleared cells are still marked in the cosmap as obstacles. The `cleared_point` flag solves this.

(11/05) Edit: Updated to better describe the work that was done.