### PR TITLE
Fix voxel visualization

### DIFF
--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -355,13 +355,14 @@ void SpatioTemporalVoxelGrid::GetOccupancyPointCloud(
   sensor_msgs::PointCloud2Iterator<float> iter_y(*pc2, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z(*pc2, "z");
 
+  double center_offset = _voxel_size/2;
   for (std::vector<geometry_msgs::msg::Point32>::iterator it =
     _grid_points->begin();
     it != _grid_points->end(); ++it)
   {
     const geometry_msgs::msg::Point32 & pt = *it;
-    *iter_x = pt.x + 0.025;
-    *iter_y = pt.y + 0.025;
+    *iter_x = pt.x + center_offset;
+    *iter_y = pt.y + center_offset;
     *iter_z = pt.z;
     ++iter_x; ++iter_y; ++iter_z;
   }

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -355,7 +355,7 @@ void SpatioTemporalVoxelGrid::GetOccupancyPointCloud(
   sensor_msgs::PointCloud2Iterator<float> iter_y(*pc2, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z(*pc2, "z");
 
-  double center_offset = _voxel_size/2;
+  const double & center_offset = _voxel_size / 2.0;
   for (std::vector<geometry_msgs::msg::Point32>::iterator it =
     _grid_points->begin();
     it != _grid_points->end(); ++it)

--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -360,8 +360,8 @@ void SpatioTemporalVoxelGrid::GetOccupancyPointCloud(
     it != _grid_points->end(); ++it)
   {
     const geometry_msgs::msg::Point32 & pt = *it;
-    *iter_x = pt.x;
-    *iter_y = pt.y;
+    *iter_x = pt.x + 0.025;
+    *iter_y = pt.y + 0.025;
     *iter_z = pt.z;
     ++iter_x; ++iter_y; ++iter_z;
   }


### PR DESCRIPTION
Voxel visualization currently outputs a pointcloud where the x and y coordinates of each point are the coordinates of the corner of the voxel. This can be confusing while debugging in rviz as illustrated below: 
- costmap lethal pixels are in pink
- input stvl sensor pointcloud is the small blue spheres (one is green due to transparency)
- voxel visualization is in green and displayed as 0.05 boxes with alpha 0.4
- both the costmap and stvl have a resolution of 0.05
![voxels](https://user-images.githubusercontent.com/15727892/135615830-98f1f5d3-adc8-4c1c-97fe-1a5bea518c4d.png)
One should naively expect to have the green boxes and the costmap pixels aligned.

This PR proposes to change the behavior by centering the points of the voxel visualization pointcloud on the voxels they are suppose to represent.
