### PR TITLE
Fix package.xml sequence

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   
@@ -35,7 +34,7 @@
   <depend>libopenexr-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-
+  <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <costmap_2d plugin="${prefix}/costmap_plugins.xml" />
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
According to the [xml schema](http://download.ros.org/schema/package_format3.xsd#:~:text=%3Cxs%3Aelement%20name%3D%22-,member_of_group,-%22%20type%3D%22ConditionalType%22%20minOccurs), `member_of_group` is part of a xs:sequence and should come after all the dependencies.

My editor was complaining 
![image](https://user-images.githubusercontent.com/14879660/153591439-896e6652-4bf8-46fb-9aa0-cfae6efe3fc9.png)
