### PR TITLE
Remove unused parameter max_obstacle_height

### DIFF
--- a/example/constrained_indoor_environment_config.yaml
+++ b/example/constrained_indoor_environment_config.yaml
@@ -8,7 +8,6 @@ global_costmap:
         decay_model:              0     # 0=linear, 1=exponential, -1=persistent
         voxel_size:               0.05  # meters
         track_unknown_space:      true  # default space is known
-        max_obstacle_height:      2.0   # meters
         unknown_threshold:        15    # voxel height
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true

--- a/example/outdoor_environment_config.yaml
+++ b/example/outdoor_environment_config.yaml
@@ -8,7 +8,6 @@ global_costmap:
         decay_model:              0     # 0=linear, 1=exponential, -1=persistent
         voxel_size:               0.05  # meters
         track_unknown_space:      true  # default space is known
-        max_obstacle_height:      2.0   # meters
         unknown_threshold:        15    # voxel height
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true

--- a/example/standard_indoor_environment_config.yaml
+++ b/example/standard_indoor_environment_config.yaml
@@ -8,7 +8,6 @@ global_costmap:
         decay_model:              0     # 0=linear, 1=exponential, -1=persistent
         voxel_size:               0.05  # meters
         track_unknown_space:      true  # default space is known
-        max_obstacle_height:      2.0   # meters
         unknown_threshold:        15    # voxel height
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true

--- a/example/vlp16_config.yaml
+++ b/example/vlp16_config.yaml
@@ -8,7 +8,6 @@ global_costmap:
         decay_model:              0     # 0=linear, 1=exponential, -1=persistent
         voxel_size:               0.05  # meters
         track_unknown_space:      true  # default space is known
-        max_obstacle_height:      2.0   # meters
         unknown_threshold:        15    # voxel height
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   
@@ -35,7 +34,7 @@
   <depend>libopenexr-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-
+  <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <costmap_2d plugin="${prefix}/costmap_plugins.xml" />
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
I think max_obstacle_height is defined twice unintentionally. I don't see the one in the upper level being read anywhere