### PR TITLE
Add missing tf2_sensor_msgs dependency for tf2::doTransform(PointCloud2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   tf2_ros
   tf2_geometry_msgs
+  tf2_sensor_msgs
   visualization_msgs
   message_generation
   dynamic_reconfigure
@@ -95,6 +96,7 @@ catkin_package(
         costmap_2d
         tf2_ros
         tf2_geometry_msgs
+        tf2_sensor_msgs
         visualization_msgs
         dynamic_reconfigure
     DEPENDS

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <build_depend>message_filters</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_sensor_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>libopenvdb-dev</build_depend>
@@ -40,6 +41,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_sensor_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>libopenvdb-dev</run_depend>
   <run_depend>libopenvdb</run_depend>

--- a/src/measurement_buffer.cpp
+++ b/src/measurement_buffer.cpp
@@ -37,6 +37,7 @@
 
 #include <spatio_temporal_voxel_layer/measurement_buffer.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 namespace buffer
 {


### PR DESCRIPTION
tf2::doTransform for PointCloud2 belong in the tf2_sensor_msgs package which is not listed as a dependency.