### PR TITLE
Fix "enable" parameter for observation sources

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -552,6 +552,7 @@ void SpatioTemporalVoxelLayer::activate(void)
     }
     (*buf_it)->ResetLastUpdatedTime();
   }
+
   // Add callback for dynamic parametrs
   auto node = node_.lock();
   dyn_params_handler = node->add_on_set_parameters_callback(

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -552,7 +552,6 @@ void SpatioTemporalVoxelLayer::activate(void)
     }
     (*buf_it)->ResetLastUpdatedTime();
   }
-
   // Add callback for dynamic parametrs
   auto node = node_.lock();
   dyn_params_handler = node->add_on_set_parameters_callback(

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -545,13 +545,15 @@ void SpatioTemporalVoxelLayer::activate(void)
   RCLCPP_INFO(logger_, "%s was activated.", getName().c_str());
 
   observation_subscribers_iter sub_it = _observation_subscribers.begin();
+  for (; sub_it != _observation_subscribers.end(); ++sub_it) {
+    (*sub_it)->subscribe();
+  }
+
   observation_buffers_iter buf_it = _observation_buffers.begin();
-  for (; sub_it != _observation_subscribers.end(); ++sub_it, ++buf_it) {
-    if (!(*buf_it)->IsEnabled()) {
-      (*sub_it)->unsubscribe();
-    }
+  for (; buf_it != _observation_buffers.end(); ++buf_it) {
     (*buf_it)->ResetLastUpdatedTime();
   }
+
   // Add callback for dynamic parametrs
   auto node = node_.lock();
   dyn_params_handler = node->add_on_set_parameters_callback(

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -365,6 +365,9 @@ void SpatioTemporalVoxelLayer::LaserScanCallback(
   const std::shared_ptr<buffer::MeasurementBuffer> & buffer)
 /*****************************************************************************/
 {
+  if (!buffer->IsEnabled()) {
+    return;
+  }
   // laser scan where infinity is invalid callback function
   sensor_msgs::msg::PointCloud2 cloud;
   cloud.header = message->header;
@@ -390,6 +393,9 @@ void SpatioTemporalVoxelLayer::LaserScanValidInfCallback(
   const std::shared_ptr<buffer::MeasurementBuffer> & buffer)
 /*****************************************************************************/
 {
+  if (!buffer->IsEnabled()) {
+    return;
+  }
   // Filter infinity to max_range
   float epsilon = 0.0001;
   sensor_msgs::msg::LaserScan message = *raw_message;
@@ -423,6 +429,9 @@ void SpatioTemporalVoxelLayer::PointCloud2Callback(
   const std::shared_ptr<buffer::MeasurementBuffer> & buffer)
 /*****************************************************************************/
 {
+  if (!buffer->IsEnabled()) {
+    return;
+  }
   // buffer the point cloud
   buffer->Lock();
   buffer->BufferROSCloud(*message);

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -545,15 +545,13 @@ void SpatioTemporalVoxelLayer::activate(void)
   RCLCPP_INFO(logger_, "%s was activated.", getName().c_str());
 
   observation_subscribers_iter sub_it = _observation_subscribers.begin();
-  for (; sub_it != _observation_subscribers.end(); ++sub_it) {
-    (*sub_it)->subscribe();
-  }
-
   observation_buffers_iter buf_it = _observation_buffers.begin();
-  for (; buf_it != _observation_buffers.end(); ++buf_it) {
+  for (; sub_it != _observation_subscribers.end(); ++sub_it, ++buf_it) {
+    if (!(*buf_it)->IsEnabled()) {
+      (*sub_it)->unsubscribe();
+    }
     (*buf_it)->ResetLastUpdatedTime();
   }
-
   // Add callback for dynamic parametrs
   auto node = node_.lock();
   dyn_params_handler = node->add_on_set_parameters_callback(


### PR DESCRIPTION
I noticed that if we set `enabled: false` for [observation sources](https://github.com/SteveMacenski/spatio_temporal_voxel_layer/blob/94e8439f7d1ff7038ce9c1138df5d2e7c743dbc2/src/spatio_temporal_voxel_layer.cpp#L239) it doesn't actually disable them on startup.
I think the problem is that `enabled` parameter is responsible for creating / destroying subscription only on service call, and is not considered for the subscription creation on startup. Or am I missing smth?

In this PR I propose to add checking for `enabled` parameter on startup to make sure that the observation source is not subsrcibed to the topic if it is disabled

Another approach could be to use [this implementation](https://github.com/ros2/message_filters/blob/de46fa8086f4b5586ea3ea80fcbbce8984ad15d2/include/message_filters/subscriber.h#L203) 
In short:
Create subscription objects without actually subscribing to the topic, then subscribe to the topics from `activate` function and only for observation sources which are enabled

Wanted to get your thoughts about implementation. Maybe you have other ideas?