### PR TITLE
add 'enabled' parameter to set dynamically

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -902,6 +902,33 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
         }
       }
     }
+
+    if (type == ParameterType::PARAMETER_BOOL) {
+      if (name == name_ + "." + "enabled") {
+        bool enable = parameter.as_bool();
+        if (enabled_ != enable) {
+          if (enable){
+            observation_subscribers_iter sub_it = _observation_subscribers.begin();
+            for (; sub_it != _observation_subscribers.end(); ++sub_it) {
+              (*sub_it)->subscribe();
+            }
+
+            observation_buffers_iter buf_it = _observation_buffers.begin();
+            for (; buf_it != _observation_buffers.end(); ++buf_it) {
+              (*buf_it)->ResetLastUpdatedTime();
+            }
+          } else {
+            observation_subscribers_iter sub_it = _observation_subscribers.begin();
+            for (; sub_it != _observation_subscribers.end(); ++sub_it) {
+              if (*sub_it != NULL) {
+                (*sub_it)->unsubscribe();
+              }
+            }
+          }
+        }
+        enabled_ = enable;
+      }
+    }
   }
 
   result.successful = true;

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -578,7 +578,7 @@ void SpatioTemporalVoxelLayer::deactivate(void)
 
   observation_subscribers_iter sub_it = _observation_subscribers.begin();
   for (; sub_it != _observation_subscribers.end(); ++sub_it) {
-    if (*sub_it != NULL) {
+    if (*sub_it != nullptr) {
       (*sub_it)->unsubscribe();
     }
   }
@@ -910,17 +910,21 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
           if (enable) {
             observation_subscribers_iter sub_it = _observation_subscribers.begin();
             for (; sub_it != _observation_subscribers.end(); ++sub_it) {
-              (*sub_it)->subscribe();
+              if (*sub_it != nullptr) {
+                (*sub_it)->subscribe();
+              }
             }
 
             observation_buffers_iter buf_it = _observation_buffers.begin();
             for (; buf_it != _observation_buffers.end(); ++buf_it) {
-              (*buf_it)->ResetLastUpdatedTime();
+              if (*buf_it != nullptr) {
+                (*buf_it)->ResetLastUpdatedTime();
+              }
             }
           } else {
             observation_subscribers_iter sub_it = _observation_subscribers.begin();
             for (; sub_it != _observation_subscribers.end(); ++sub_it) {
-              if (*sub_it != NULL) {
+              if (*sub_it != nullptr) {
                 (*sub_it)->unsubscribe();
               }
             }

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -907,7 +907,7 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
       if (name == name_ + "." + "enabled") {
         bool enable = parameter.as_bool();
         if (enabled_ != enable) {
-          if (enable){
+          if (enable) {
             observation_subscribers_iter sub_it = _observation_subscribers.begin();
             for (; sub_it != _observation_subscribers.end(); ++sub_it) {
               (*sub_it)->subscribe();


### PR DESCRIPTION
There was already a service that had a function similar to toggle stvl. (service name: `<observation_topic>/toggle_enabled`)
The service can be set up for each individual topic, but I wanted a toggle function for the entire stvl.

So I implemented the function and made it dynamically configurable.

I referred to the functions(activate, deactivate).