### PR TITLE
Allow mark_threshold parameter to be set dynamically

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -933,6 +933,12 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
         enabled_ = enable;
       }
     }
+
+    if (type == ParameterType::PARAMETER_INTEGER) {
+      if (name == name_ + "." + "mark_threshold") {
+        _mark_threshold = parameter.as_int();
+      }
+    }
   }
 
   result.successful = true;


### PR DESCRIPTION
Hello! :slightly_smiling_face: In my usecase sometimes I need to disable marking the costmap, but keep publishing STVL to the topic, and reconfiguring mark_threshold is the way to go for me.
So if you think it could be useful for somebody else then I propose to add the ability to set dynamically `mark_threshold` parameter