### PR TITLE
reset grid on disable

### DIFF
--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -457,6 +457,7 @@ void SpatioTemporalVoxelLayer::BufferEnablerCallback(
       response->message = "Enabling sensor";
     } else if (subcriber) {
       subcriber->unsubscribe();
+      ResetGrid();
       response->message = "Disabling sensor";
     }
   } else {


### PR DESCRIPTION
When disabling a source, it would make sense that its perceived voxels are cleared immediately as well and not left to expire