### PR TITLE
Fix memory consumption issue

### DIFF
--- a/src/spatio_temporal_voxel_grid.cpp
+++ b/src/spatio_temporal_voxel_grid.cpp
@@ -250,6 +250,9 @@ void SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap(                \
       PopulateCostmapAndPointcloud(pt_index);
     }
   }
+
+  // free memory taken by expired voxels
+  _grid->pruneGrid();
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
## Description

- Implementation of the solution proposed in #270.

By calling `openvdb::Grid::prune` at the end of `SpatioTemporalVoxelGrid::TemporalClearAndGenerateCostmap` we can free the memory being taken by expired voxels.

I measured execution time of the prune function and it was under 1ms, so I don't think it should have any major impact on performance.

```cpp
const auto start = ros::WallTime::now();
_grid->pruneGrid();
ROS_ERROR_STREAM("dt: " << (ros::WallTime::now() - start).toNSec() / 1e6);
```

## Demo

After this fix, the memory taken by the grid goes down every time the voxels are expired.

However, note that htop doesn't reflect this and the memory consumption never goes down (although it's a lot lower than before).
I'm not sure why this is happening, but maybe something related with linux internal workings?
Even though the process isn't using the memory anymore, linux still thinks it is?
I'm not too familiar with this, but at least from the logs it's clear to see that the memory consumption of the grid does indeed go down every time voxels are expired.

You can also test this without the change in this PR:
- Let the robot move and memory consumption increase (let's say 10mb)
- Manually call clear costmap service, which will clear the grid
- Confirm that the logs do indeed show that the grid was cleared and memory was freed
- htop still shows stvl taking those 10mb of memory

### Before

https://github.com/SteveMacenski/spatio_temporal_voxel_layer/assets/15384781/00b11a9d-d68e-43ca-ba9c-505d289494b7

### After

https://github.com/SteveMacenski/spatio_temporal_voxel_layer/assets/15384781/cfc8e78e-6bc4-446a-9d22-4d8450c4526b