### PR TITLE
chore: Install header files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,3 +151,6 @@ install(FILES costmap_plugins.xml test/minimal_test.launch
 install(DIRECTORY example
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
This would allow users installing the package to derive interfaces (eg. extend STVL).