### PR TITLE
build openvdb with CMAKE_BUILD_TYPE "Release"

### DIFF
--- a/openvdb_vendor/openvdb_vendor-extras.cmake
+++ b/openvdb_vendor/openvdb_vendor-extras.cmake
@@ -1,2 +1,7 @@
+# Default to Release build
+if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
+message( STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" )
 list(APPEND CMAKE_MODULE_PATH "${openvdb_vendor_DIR}/../../../opt/openvdb_vendor/lib/cmake/OpenVDB")
 find_package(OpenVDB REQUIRED)


### PR DESCRIPTION
Without this change, I STVL+MPPI takes about ~350ms per iteration of the controller
After the change, each iteraation time drops down to ~30ms.

![Screenshot from 2024-04-04 13-10-48](https://github.com/SteveMacenski/spatio_temporal_voxel_layer/assets/123109010/ed719c49-b360-4d9b-a7b6-ed84f8aefb2a)
![Screenshot from 2024-04-04 15-26-21](https://github.com/SteveMacenski/spatio_temporal_voxel_layer/assets/123109010/1a231492-6a25-460d-87dc-82c88cadb505)
