### PR TITLE
Fix pub_options callback group not set

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -144,7 +144,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   sub_opt.callback_group = callback_group_;
 
   auto pub_opt = rclcpp::PublisherOptions();
-  sub_opt.callback_group = callback_group_;
+  pub_opt.callback_group = callback_group_;
 
   _voxel_pub = node->create_publisher<sensor_msgs::msg::PointCloud2>(
     "voxel_grid", rclcpp::QoS(1), pub_opt);


### PR DESCRIPTION
This PR fixes #297 and sets the `callback_group` of the publisher options for the `voxel_grid` publisher. Before the `callback_group` for the subscriber options was set twice.

Tested on humble with no perceptible changes, everything seems working fine. I don't know exactly the consequences of not setting the callback_group (e.g. `get_subscription_count()` was also working even with the default options without setting it), but it makes more sense to fix this typo now and prevent future problems. 