### PR TITLE
Change libpcl-all to libpcl-all-dev

### DIFF
--- a/spatio_temporal_voxel_layer/package.xml
+++ b/spatio_temporal_voxel_layer/package.xml
@@ -22,7 +22,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>laser_geometry</depend>
-  <depend>libpcl-all</depend>
+  <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>message_filters</depend>


### PR DESCRIPTION
I tried to rosdep and build the package in ros:jazzy docker image and got 

```
root@16614e295025:~/ros_ws# colcon build --packages-select spatio_temporal_voxel_layer
Starting >>> spatio_temporal_voxel_layer
--- stderr: spatio_temporal_voxel_layer                         
CMake Error at /opt/ros/jazzy/share/pcl_conversions/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  By not providing "FindPCL.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PCL", but
  CMake did not find one.

  Could not find a package configuration file provided by "PCL" with any of
  the following names:

    PCLConfig.cmake
    pcl-config.cmake

  Add the installation prefix of "PCL" to CMAKE_PREFIX_PATH or set "PCL_DIR"
  to a directory containing one of the above files.  If "PCL" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /opt/ros/jazzy/share/pcl_conversions/cmake/pcl_conversionsConfig.cmake:41 (include)
  CMakeLists.txt:22 (find_package)


---
Failed   <<< spatio_temporal_voxel_layer [0.76s, exited with code 1]
```

Turns out `libpcl-dev` is not being installed. Switching to `libpcl-all-dev` in package.xml fixes that. I'm not sure though whether we are adding many more unnecessary dependencies though. 

