### PR TITLE
Relative Variants of Voxel and Passthrough Filters and Footprint Projection for Slope Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Required dependencies ROS Kinetic, navigation, OpenVDB, TBB.
 
 An example fully-described configuration is shown below.
 
-Note: We supply two PCL filters within STVL to massage the data to lower compute overhead. STVL has an approximate voxel filter to make the data more sparse if very dense. It also has a passthrough filter to limit processing data within the valid minimum to maximum height bounds. The voxel filter is recommended if it lowers CPU overhead, otherwise, passthrough filter. No filter is also available if you pre-process your data or are not interested in performance optimizations. 
+Note: We supply two PCL filters within STVL to massage the data to lower compute overhead. STVL has an approximate voxel filter to make the data more sparse if very dense. It also has a passthrough filter to limit processing data within the valid minimum to maximum height bounds. The voxel filter is recommended if it lowers CPU overhead, otherwise, passthrough filter. No filter is also available if you pre-process your data or are not interested in performance optimizations. Filters have "relative" variants made to use robot's frame for obstacle classification instead of the global frame in case of navigating sloped surfaces.
 
 ```
 rgbd_obstacle_layer:
@@ -113,7 +113,9 @@ rgbd_obstacle_layer:
   observation_persistence: 0.0  #seconds
   max_obstacle_height:   2.0    #meters
   mark_threshold:        0      #voxel height
-  update_footprint_enabled: true
+  update_footprint_enabled: true 
+  footprint_projection_enabled: true #default off, recommended when using 3d IMU data. Uses tf2 to transform the footprint
+  robot_base_frame: "base_link" #frame to use with footprint_projection_enabled
   combination_method:    1      #1=max, 0=override
   obstacle_range:        3.0    #meters
   origin_z:              0.0    #meters
@@ -133,7 +135,8 @@ rgbd_obstacle_layer:
     observation_persistence: 0.0 #default 0, use all measurements taken during now-value, 0=latest 
     inf_is_valid: false          #default false, for laser scans
     clear_after_reading: true    #default false, clear the buffer after the layer gets readings from it
-    filter: "voxel"              #default passthrough, apply "voxel", "passthrough", or no filter to sensor data, recommended to have at one filter on
+    filter: "voxel"              #default passthrough, apply "voxel", "passthrough", "voxel_relative", "passthrough_relative", or no filter to sensor data, recommended to have at one filter on
+    z_reference_frame: "base_link" #default global_frame, use with *_relative filters as a frame for obstacle classification based on z coordinate
     voxel_min_points: 0          #default 0, minimum points per voxel for voxel filter
   rgbd1_clear:
     enabled: true                #default true, can be toggled on/off with associated service call

--- a/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
+++ b/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
@@ -10,6 +10,8 @@ global_costmap:
         track_unknown_space:      true  # default space is known
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true
+        footprint_projection_enabled: true # default off, strongly recommended when using 3d IMU data
+        footprint_frame: "base_link" # necessary for use with footprint projection, 
         combination_method:       1     # 1=max, 0=override
         origin_z:                 0.0   # meters
         publish_voxel_map:        false # default off

--- a/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
+++ b/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
@@ -1,0 +1,45 @@
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      rgbd_obstacle_layer:
+        plugin: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"
+        enabled:                  true
+        voxel_decay:              1.0  # seconds if linear, e^n if exponential
+        decay_model:              0     # 0=linear, 1=exponential, -1=persistent
+        voxel_size:               0.05  # meters
+        track_unknown_space:      true  # default space is known
+        mark_threshold:           0     # voxel height
+        update_footprint_enabled: true
+        combination_method:       1     # 1=max, 0=override
+        origin_z:                 0.0   # meters
+        publish_voxel_map:        false # default off
+        transform_tolerance:      0.2   # seconds
+        mapping_mode:             false # default off, saves map not for navigation
+        map_save_duration:        60.0  # default 60s, how often to autosave
+        observation_sources:      rgbd1_mark rgbd1_clear
+        rgbd1_mark:
+          data_type: PointCloud2
+          topic: camera1/depth/points
+          marking: true
+          clearing: false
+          obstacle_range: 3.0          # meters
+          min_obstacle_height: 0.3     # default 0, meters
+          max_obstacle_height: 2.0     # default 3, meters
+          expected_update_rate: 0.0    # default 0, if not updating at this rate at least, remove from buffer
+          observation_persistence: 0.0 # default 0, use all measurements taken during now-value, 0=latest
+          inf_is_valid: false          # default false, for laser scans
+          filter: "passthrough_relative"        # default passthrough, apply "voxel", "passthrough", their relative variants or no filter to sensor data, recommend on 
+          z_reference_frame: "base_link" # if unspecified keeps using global frame for z filter, frame to calcualte the z coordinate before transforming pointcloud to global frame
+          voxel_min_points: 0          # default 0, minimum points per voxel for voxel filter
+          clear_after_reading: true    # default false, clear the buffer after the layer gets readings from it
+        rgbd1_clear:
+          data_type: PointCloud2
+          topic: camera1/depth/points
+          marking: false
+          clearing: true
+          max_z: 7.0                  # default 0, meters
+          min_z: 0.1                  # default 10, meters
+          vertical_fov_angle: 0.8745  # default 0.7, radians
+          horizontal_fov_angle: 1.048 # default 1.04, radians
+          decay_acceleration: 1.0     # default 0, 1/s^2. If laser scanner MUST be 0
+          model_type: 0                # default 0, model type for frustum. 0=depth camera, 1=3d lidar like VLP16 or similar

--- a/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
+++ b/spatio_temporal_voxel_layer/example/uneven_terrain_config.yaml
@@ -11,7 +11,7 @@ global_costmap:
         mark_threshold:           0     # voxel height
         update_footprint_enabled: true
         footprint_projection_enabled: true # default off, strongly recommended when using 3d IMU data
-        footprint_frame: "base_link" # necessary for use with footprint projection, 
+        robot_base_frame: "base_link" # necessary for use with footprint projection, 
         combination_method:       1     # 1=max, 0=override
         origin_z:                 0.0   # meters
         publish_voxel_map:        false # default off

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -73,7 +73,9 @@ enum class Filters
 {
   NONE = 0,
   VOXEL = 1,
-  PASSTHROUGH = 2
+  PASSTHROUGH = 2,
+  VOXEL_RELATIVE = 3,
+  PASSTHROUGH_RELATIVE = 4
 };
 
 // conveniences for line lengths
@@ -95,6 +97,7 @@ public:
     tf2_ros::Buffer & tf,
     const std::string & global_frame,
     const std::string & sensor_frame,
+    const std::string & z_reference_frame,
     const double & tf_tolerance,
     const double & min_d,
     const double & max_d,
@@ -155,7 +158,7 @@ private:
   const rclcpp::Duration _observation_keep_time, _expected_update_rate;
   rclcpp::Time _last_updated;
   boost::recursive_mutex _lock;
-  std::string _global_frame, _sensor_frame, _source_name, _topic_name;
+  std::string _global_frame, _sensor_frame, _source_name, _topic_name, _z_reference_frame;
   std::list<observation::MeasurementReading> _observation_list;
   double _min_obstacle_height, _max_obstacle_height, _obstacle_range, _tf_tolerance;
   double _min_z, _max_z, _vertical_fov, _vertical_fov_padding, _horizontal_fov;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -180,7 +180,7 @@ private:
   rclcpp::Service<spatio_temporal_voxel_layer::srv::SaveGrid>::SharedPtr _grid_saver;
   std::unique_ptr<rclcpp::Duration> _map_save_duration;
   rclcpp::Time _last_map_save_time;
-  std::string _global_frame, _footprint_frame;
+  std::string _global_frame, _robot_base_frame;
   double _voxel_size, _voxel_decay;
   int _combination_method, _mark_threshold;
   volume_grid::GlobalDecayModel _decay_model;
@@ -191,7 +191,6 @@ private:
   boost::recursive_mutex _voxel_grid_lock;
 
   std::string _topics_string;
-
 
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -76,7 +76,7 @@
 #include "message_filters/subscriber.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/buffer_core.h"
-
+#include "tf2_ros/buffer.h"
 namespace spatio_temporal_voxel_layer
 {
 
@@ -180,17 +180,18 @@ private:
   rclcpp::Service<spatio_temporal_voxel_layer::srv::SaveGrid>::SharedPtr _grid_saver;
   std::unique_ptr<rclcpp::Duration> _map_save_duration;
   rclcpp::Time _last_map_save_time;
-  std::string _global_frame;
+  std::string _global_frame, _footprint_frame;
   double _voxel_size, _voxel_decay;
   int _combination_method, _mark_threshold;
   volume_grid::GlobalDecayModel _decay_model;
-  bool _update_footprint_enabled, _enabled;
+  bool _update_footprint_enabled, _footprint_projection_enabled, _enabled;
   std::vector<geometry_msgs::msg::Point> _transformed_footprint;
   std::vector<observation::MeasurementReading> _static_observations;
   std::unique_ptr<volume_grid::SpatioTemporalVoxelGrid> _voxel_grid;
   boost::recursive_mutex _voxel_grid_lock;
 
   std::string _topics_string;
+
 
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -135,6 +135,9 @@ public:
     std::shared_ptr<spatio_temporal_voxel_layer::srv::SaveGrid::Response> resp);
 
 private:
+  // clock
+  rclcpp::Clock::SharedPtr _clock;
+
   // Sensor callbacks
   void LaserScanCallback(
     sensor_msgs::msg::LaserScan::ConstSharedPtr message,

--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -146,10 +146,13 @@ void MeasurementBuffer::BufferROSCloud(
     // remove points that are below or above our height restrictions, and
     // in the same time, remove NaNs and if user wants to use it, combine with a
 
+    geometry_msgs::msg::TransformStamped tf_direct_global, tf_z_reference, tf_global_from_z_reference;
+
+
     switch (_filter)
     {
     case Filters::PASSTHROUGH :
-      geometry_msgs::msg::TransformStamped tf_direct_global =
+      tf_direct_global =
         _buffer.lookupTransform(
         _global_frame, cloud.header.frame_id,
         tf2_ros::fromMsg(cloud.header.stamp));
@@ -164,7 +167,7 @@ void MeasurementBuffer::BufferROSCloud(
       pcl_conversions::fromPCL(*cloud_filtered, *cld_transformed);
       break;
     case Filters::VOXEL :
-      geometry_msgs::msg::TransformStamped tf_direct_global =
+      tf_direct_global =
         _buffer.lookupTransform(
         _global_frame, cloud.header.frame_id,
         tf2_ros::fromMsg(cloud.header.stamp));
@@ -180,11 +183,11 @@ void MeasurementBuffer::BufferROSCloud(
       pcl_conversions::fromPCL(*cloud_filtered, *cld_transformed);
       break;
     case Filters::PASSTHROUGH_RELATIVE :
-      geometry_msgs::msg::TransformStamped tf_z_reference =
+      tf_z_reference =
         _buffer.lookupTransform(
         _z_reference_frame, cloud.header.frame_id,
         tf2_ros::fromMsg(cloud.header.stamp));
-      geometry_msgs::msg::TransformStamped tf_global_from_z_reference =
+      tf_global_from_z_reference =
         _buffer.lookupTransform(
         _global_frame, _z_reference_frame,
         tf2_ros::fromMsg(cloud.header.stamp));
@@ -200,11 +203,11 @@ void MeasurementBuffer::BufferROSCloud(
       tf2::doTransform(*cld_transformed, *cld_transformed, tf_global_from_z_reference);
       break;
     case Filters::VOXEL_RELATIVE :
-      geometry_msgs::msg::TransformStamped tf_z_reference =
+      tf_z_reference =
         _buffer.lookupTransform(
         _z_reference_frame, cloud.header.frame_id,
         tf2_ros::fromMsg(cloud.header.stamp));
-      geometry_msgs::msg::TransformStamped tf_global_from_z_reference =
+      tf_global_from_z_reference =
         _buffer.lookupTransform(
         _global_frame, _z_reference_frame,
         tf2_ros::fromMsg(cloud.header.stamp));

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -164,6 +164,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     node->get_clock(), _voxel_size, static_cast<double>(default_value_), _decay_model,
     _voxel_decay, _publish_voxels);
 
+  _clock = node->get_clock();
+
   matchSize();
 
   RCLCPP_INFO(logger_, "%s created underlying voxel grid.", getName().c_str());
@@ -566,10 +568,11 @@ bool SpatioTemporalVoxelLayer::updateFootprint(
   } else {
     // Using tf2 for 3d rotation to provide accurate projection of the footprint
     try {
+      rclcpp::Time current_time = _clock->now();
       geometry_msgs::msg::TransformStamped tf_footprint_stamped =
         tf_->lookupTransform(
           _global_frame, _robot_base_frame,
-          rclcpp::Clock.now()); 
+          current_time ); 
       for (unsigned int i = 0; i < _transformed_footprint.size(); i++) {
         tf2::doTransform(_transformed_footprint[i], _transformed_footprint[i], tf_footprint_stamped);       
         touch(

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -570,11 +570,10 @@ bool SpatioTemporalVoxelLayer::updateFootprint(
         tf_->lookupTransform(
           _global_frame, _robot_base_frame,
           rclcpp::Clock.now()); 
-      std::vector<geometry_msgs::Point> temp_footprint = getFootprint();
-      for (unsigned int i = 0; i < temp_footprint.size(); i++) {
-        tf2::doTransform(temp_footprint[i], temp_footprint[i], tf_footprint_stamped);       
+      for (unsigned int i = 0; i < _transformed_footprint.size(); i++) {
+        tf2::doTransform(_transformed_footprint[i], _transformed_footprint[i], tf_footprint_stamped);       
         touch(
-          temp_footprint[i].x, temp_footprint[i].y,
+          _transformed_footprint[i].x, _transformed_footprint[i].y,
           min_x, min_y, max_x, max_y);
       }
     } catch (tf2::TransformException &ex) {

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -245,28 +245,22 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     node->get_parameter(name_ + "." + source + "." + "model_type", model_type_int);
     ModelType model_type = static_cast<ModelType>(model_type_int);
 
-    switch (filter)
-    {
-    case "passthrough":
+
+    if (filter_str == "passthrough") {
       RCLCPP_INFO(logger_, "Passthough filter activated.");
       filter = buffer::Filters::PASSTHROUGH;
-      break;
-    case "voxel":
+    } else if (filter_str == "voxel") {
       RCLCPP_INFO(logger_, "Voxel filter activated.");
       filter = buffer::Filters::VOXEL;
-      break;
-    case "passthrough_relative":
+    } else if (filter_str == "passthrough_relative") {
       RCLCPP_INFO(logger_, "Relative Passthough filter activated.");
       filter = buffer::Filters::PASSTHROUGH_RELATIVE;
-      break;
-    case "voxel_relative":
+    } else if (filter_str == "voxel_relative") {
       RCLCPP_INFO(logger_, "Relative Voxel filter activated.");
       filter = buffer::Filters::VOXEL_RELATIVE;
-      break;    
-    default:
+    }  else {
       RCLCPP_INFO(logger_, "No filters activated.");
       filter = buffer::Filters::NONE;
-      break;
     }
 
     if (!(data_type == "PointCloud2" || data_type == "LaserScan")) {
@@ -280,7 +274,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
         new buffer::MeasurementBuffer(
           source, topic,
           observation_keep_time, expected_update_rate, min_obstacle_height,
-          max_obstacle_height, obstacle_range, *tf_, _global_frame, sensor_frame,
+          max_obstacle_height, obstacle_range, *tf_, _global_frame, sensor_frame, z_reference_frame,
           transform_tolerance, min_z, max_z, vFOV, vFOVPadding, hFOV,
           decay_acceleration, marking, clearing, _voxel_size,
           filter, voxel_min_points, enabled, clear_after_reading, model_type,


### PR DESCRIPTION
### **[Feature] Added Relative Variants of Voxel and Passthrough Filters and Footprint Projection for Slope Navigation**

#### **Summary**
This PR introduces new "relative" variants of the voxel and passthrough filters, which allow for more accurate obstacle detection on non-horizontal surfaces. By making the obstacle detection bounds relative to a customizable `z_reference_frame` (rather than the world frame), robots can now navigate uneven terrain without encountering the previous issues observed in Gazebo with the robot_localization and Nav2 stacks. The feature for clearing the robot footprint was also updated to provide an option to use 3D IMU orientation to project the footprint on the costmap.

These updates ensure improved behavior when broadcasting the robot's state with both 3D IMU orientation and `z` position on slopes, without causing unexpected navigation issues. The changes are implemented to ensure full backward compatibility with projects running the current version of SVTL.

#### **Problem Description**
- **Problems with using the robot's `z` position:** Since obstacle bounds are relative to the world frame, any change in the robot's `z` position altered the effective obstacle heights for the robot.
- **Incorrect Obstacle Detection on Slopes:** When using full 3D IMU orientation data, robots navigating slopes experienced improper obstacle detection, which could be dangerous, especially on downhill slopes. Obstacles' `z` coordinates in the world frame were not registered correctly since their global `z` coordinate was smaller than their height relative to the surface. On uphill slopes, the terrain itself could be mistakenly registered as an obstacle.
- **Inconsistent Localization on 2D Costmaps:** Using fully 2D localization created inconsistencies between GPS-based metrics and LiDAR-based metrics on a 2D costmap. This caused static obstacles to appear to "move" and become distorted as the robot moved on bumpy or sloped surfaces.

#### **Solution**
The newly introduced "relative" filter variants enable the robot’s obstacle detection to account for slopes by using the `z_reference_frame` parameter from the observation source, rather than relying on the world frame. This achieves:
- **Slope-Compatible Obstacle Detection:** The obstacle bounds adjust dynamically based on the robot’s current frame, allowing it to navigate traversable slopes and detect obstacles on them.
- **Enabling SVTL use while tracking the robot's `z` position:** This ensures consistent behavior regardless of altitude relative to the world frame.

> Note: With relative filters, obstacles directly in front of the robot may still be inside the footprint transformed without considering the robot's 3D rotation.

This issue was solved by introducing a footprint projection feature, which, if enabled, processes clearing the robot's footprint by transforming it using `tf2` instead of the `Costmap2D` footprint transformation. This provides an accurate projection of the footprint on the XY plane.

#### **Known Limitations**
- **Drastic Slope Changes:** The relative filters may still detect drastic slope changes as obstacles (e.g., transitioning from steep declines to inclines).
- **No Absolute Slope Limit Safeguard:** The current filters do not provide a mechanism to restrict obstacle detection based on a maximum slope. Further development with more complex point cloud analysis will be required to handle such cases.

#### **Usage**
To use the new features, the configuration file needs to be modified:
- Use the `"voxel_relative"` and `"passthrough_relative"` values for the filter attribute of the observation source.
- The `z_reference_frame` parameter, added to the observation source, sets the frame used to evaluate the `z` of each point of observation to determine if it is an obstacle. It defaults to the world frame of the layered costmap.
- `footprint_projection_enabled` activates projecting the footprint using `tf2` and is strongly recommended if using 3D localization. It defaults to `false`.
- `footprint_frame` sets the frame from which the footprint is transformed to the global frame. It is necessary to set this when using footprint projection. The recommended setting is the robot's base frame (manual setting is necessary because the parameter is inaccessible through the layered costmap).