### PR TITLE
Update in observation time comparison

### DIFF
--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -218,7 +218,7 @@ void MeasurementBuffer::RemoveStaleObservations(void)
   }
 
   for (it = _observation_list.begin(); it != _observation_list.end(); ++it) {
-    const rclcpp::Duration time_diff = _last_updated - it->_cloud->header.stamp;
+    const rclcpp::Duration time_diff = clock_->now() - it->_cloud->header.stamp;
 
     if (time_diff > _observation_keep_time) {
       _observation_list.erase(it, _observation_list.end());

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -599,6 +599,11 @@ void SpatioTemporalVoxelLayer::reset(void)
 
   current_ = false;
   was_reset_ = true;
+
+  observation_buffers_iter it = _observation_buffers.begin();
+  for (; it != _observation_buffers.end(); ++it) {
+      (*it)->ResetLastUpdatedTime();
+  }
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -599,11 +599,6 @@ void SpatioTemporalVoxelLayer::reset(void)
 
   current_ = false;
   was_reset_ = true;
-
-  observation_buffers_iter it = _observation_buffers.begin();
-  for (; it != _observation_buffers.end(); ++it) {
-    (*it)->ResetLastUpdatedTime();
-  }
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -602,7 +602,7 @@ void SpatioTemporalVoxelLayer::reset(void)
 
   observation_buffers_iter it = _observation_buffers.begin();
   for (; it != _observation_buffers.end(); ++it) {
-      (*it)->ResetLastUpdatedTime();
+    (*it)->ResetLastUpdatedTime();
   }
 }
 


### PR DESCRIPTION
The staleness of observations in the measurement buffer are now determined by comparison to clock_->now() instead of the time of last observation. Also, the last_updated is now not updated on reset.

Closes #307 