### PR TITLE
Fix ament export libraries for Jazzy

### DIFF
--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -133,5 +133,5 @@ install(FILES costmap_plugins.xml
 ament_export_dependencies(rosidl_default_runtime)
 pluginlib_export_plugin_description_file(nav2_costmap_2d costmap_plugins.xml)
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${library_name})
 ament_package()


### PR DESCRIPTION
As per #313, fix the ament_export_libraries() argument in the CMakeLists.txt in jazzy branch