### PR TITLE
Fix ResetGridArea truth table logic

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -410,7 +410,7 @@ void SpatioTemporalVoxelGrid::ResetGridArea(
     const bool in_y_range = pose_world.y() > start.y && pose_world.y() < end.y;
     const bool in_range = in_x_range && in_y_range;
 
-    if(in_range == invert_area)
+    if(in_range != invert_area)
     {
       ClearGridPoint(pt_index);
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/32d3e891-0651-4b26-9628-d0ae4050494c)
That's a XOR which is equivalent to `in_range != invert_area`.

Please double check, truth tables make me dizzy :dizzy_face: 

Btw I arrived to this by noticing that ClearCostmapExceptRegion and ClearCostmapAroundRobot were having reversed effects

If merged please also backport to Jazzy