### PR TITLE
Added mapToWorldNoBounds Function

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -961,8 +961,8 @@ void SpatioTemporalVoxelLayer::clearArea(
   // convert map coords to world coords
   volume_grid::occupany_cell start_world(0, 0);
   volume_grid::occupany_cell end_world(0, 0);
-  mapToWorld(start_x, start_y, start_world.x, start_world.y);
-  mapToWorld(end_x, end_y, end_world.x, end_world.y);
+  mapToWorldNoBounds(start_x, start_y, start_world.x, start_world.y);
+  mapToWorldNoBounds(end_x, end_y, end_world.x, end_world.y);
 
   boost::recursive_mutex::scoped_lock lock(_voxel_grid_lock);
   _voxel_grid->ResetGridArea(start_world, end_world, invert_area);


### PR DESCRIPTION
> [!NOTE]  
> [#5010](https://github.com/ros-navigation/navigation2/pull/5010) must be merged prior.

## Description

* Added mapToWorldNoBounds function for fetching map coordinates as the  [mapToWorld](https://github.com/ros-navigation/navigation2/blob/main/nav2_costmap_2d/src/costmap_2d.cpp#L279) function only takes unsigned inputs.
* This fixes issues where, due to the unsigned type in the function arguments, the entire costmap would clear due to a **Bit Underflow** and set values such as `214747867`.

