### PR TITLE
Fix build with statically-linked Python interpreter and bump minimum required version to CMake 3.16

### DIFF
--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -79,9 +79,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-# Get a linker error when there are undefined symbols
-add_link_options(-Wl,--no-undefined)
-
 include_directories(
     include
     ${BOOST_INCLUDE_DIRS}
@@ -108,6 +105,15 @@ target_link_libraries(${library_name}
   ${PCL_LIBRARIES}
   OpenVDB::openvdb
 )
+
+# Get a linker error when there are undefined symbols
+# target_link_options (https://cmake.org/cmake/help/latest/command/target_link_options.html)
+# is only available since CMake 3.13
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+  target_link_options(${library_name} PRIVATE -Wl,--no-undefined)
+else()
+  add_link_options(-Wl,--no-undefined)
+endif()
 
 ament_target_dependencies(${library_name} ${dependencies})
 

--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(spatio_temporal_voxel_layer)
 
 if(NOT WIN32)
@@ -107,13 +107,7 @@ target_link_libraries(${library_name}
 )
 
 # Get a linker error when there are undefined symbols
-# target_link_options (https://cmake.org/cmake/help/latest/command/target_link_options.html)
-# is only available since CMake 3.13
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-  target_link_options(${library_name} PRIVATE -Wl,--no-undefined)
-else()
-  add_link_options(-Wl,--no-undefined)
-endif()
+target_link_options(${library_name} PRIVATE -Wl,--no-undefined)
 
 ament_target_dependencies(${library_name} ${dependencies})
 


### PR DESCRIPTION
Thanks a lot for all the work on this project!

In https://github.com/RoboStack/ros-humble/pull/275 we tried to build it in robostack, but we experienced some linking errors, that were created by the setting of the `-Wl,--no-undefined` linking option applied to Python extensions. 

In some cases, Python extensions are intentionally **not** linked to the `libpython` shared library (as for example when linking to the `Python::Module` imported library, see https://gitlab.kitware.com/cmake/cmake/-/blob/v4.0.0/Modules/FindPython/Support.cmake?ref_type=tags#L4206), mostly to ensure support for Python interpreters that statically link the `libpython` library (see https://github.com/astral-sh/python-build-standalone/pull/540). So, in general setting `-Wl,--no-undefined` for Python extensions can lead to linkin errors.

To avoid this problem, this PR uses `target_link_options` in place of `link_options` to only set `spatio_temporal_voxel_layer_core` for the `spatio_temporal_voxel_layer_core`. The script falls back to use `link_options` if using a version of CMake <= 3.13 . 

If the minimum version of CMake required by the project can be raised to 3.16 (that was the minimum version of CMake required by ROS 2 Foxy that reached the EOL in May 2023, see https://www.ros.org/reps/rep-2000.html#foxy-fitzroy-may-2020-may-2023), the code can be simplified to remove the check on CMake ersion.