### PR TITLE
Fix compilation warnings 

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -122,7 +122,7 @@ void SpatioTemporalVoxelGrid::ClearFrustums(
   std::vector<observation::MeasurementReading>::const_iterator it =
     clearing_readings.begin();
   for (; it != clearing_readings.end(); ++it) {
-    geometry::Frustum * frustum;
+    geometry::Frustum * frustum = nullptr;
     if (it->_model_type == DEPTH_CAMERA) {
       frustum = new geometry::DepthCameraFrustum(
         it->_vertical_fov_in_rad,
@@ -401,7 +401,7 @@ void SpatioTemporalVoxelGrid::ResetGridArea(
   boost::unique_lock<boost::mutex> lock(_grid_lock);
 
   openvdb::DoubleGrid::ValueOnCIter cit_grid = _grid->cbeginValueOn();
-  for (cit_grid; cit_grid.test(); ++cit_grid)
+  for (; cit_grid.test(); ++cit_grid)
   {
     const openvdb::Coord pt_index(cit_grid.getCoord());
     const openvdb::Vec3d pose_world = this->IndexToWorld(pt_index);

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -152,7 +152,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   auto save_grid_callback = std::bind(
     &SpatioTemporalVoxelLayer::SaveGridCallback, this, _1, _2, _3);
   _grid_saver = node->create_service<spatio_temporal_voxel_layer::srv::SaveGrid>(
-    "save_grid", save_grid_callback, rmw_qos_profile_services_default, callback_group_);
+    "save_grid", save_grid_callback, rclcpp::SystemDefaultsQoS(), callback_group_);
 
   _voxel_grid = std::make_unique<volume_grid::SpatioTemporalVoxelGrid>(
     node->get_clock(), _voxel_size, static_cast<double>(default_value_), _decay_model,
@@ -331,7 +331,6 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
       _observation_subscribers.push_back(sub);
       _observation_notifiers.push_back(filter);
     }
-
     std::function<void(const std::shared_ptr<rmw_request_id_t>,
       std_srvs::srv::SetBool::Request::SharedPtr,
       std_srvs::srv::SetBool::Response::SharedPtr)> toggle_srv_callback;
@@ -342,7 +341,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
       _observation_subscribers.back());
     std::string toggle_topic = source + "/toggle_enabled";
     auto server = node->create_service<std_srvs::srv::SetBool>(
-      toggle_topic, toggle_srv_callback, rmw_qos_profile_services_default, callback_group_);
+      toggle_topic, toggle_srv_callback, rclcpp::SystemDefaultsQoS(), callback_group_);
 
     _buffer_enabler_servers.push_back(server);
 


### PR DESCRIPTION
Before the fix:
```cpp
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp: In member function ‘void volume_grid::SpatioTemporalVoxelGrid::ResetGridArea(const volume_grid::occupany_cell&, const volume_grid::occupany_cell&, bool)’:
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp:404:8: warning: statement has no effect [-Wunused-value]
  404 |   for (cit_grid; cit_grid.test(); ++cit_grid)
      |        ^~~~~~~~
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp: In member function ‘virtual void spatio_temporal_voxel_layer::SpatioTemporalVoxelLayer::onInitialize()’:
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp:154:81: warning: ‘typename rclcpp::Service<ServiceT>::SharedPtr rclcpp_lifecycle::LifecycleNode::create_service(const std::string&, CallbackT&&, const rmw_qos_profile_t&, rclcpp::CallbackGroup::SharedPtr) [with ServiceT = spatio_temporal_voxel_layer::srv::SaveGrid; CallbackT = std::_Bind<void (spatio_temporal_voxel_layer::SpatioTemporalVoxelLayer::*(spatio_temporal_voxel_layer::SpatioTemporalVoxelLayer*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(std::shared_ptr<rmw_request_id_s>, std::shared_ptr<spatio_temporal_voxel_layer::srv::SaveGrid_Request_<std::allocator<void> > >, std::shared_ptr<spatio_temporal_voxel_layer::srv::SaveGrid_Response_<std::allocator<void> > >)>&; typename rclcpp::Service<ServiceT>::SharedPtr = std::shared_ptr<rclcpp::Service<spatio_temporal_voxel_layer::srv::SaveGrid> >; std::string = std::__cxx11::basic_string<char>; rmw_qos_profile_t = rmw_qos_profile_s; rclcpp::CallbackGroup::SharedPtr = std::shared_ptr<rclcpp::CallbackGroup>]’ is deprecated: use rclcpp::QoS instead of rmw_qos_profile_t [-Wdeprecated-declarations]
  154 |   _grid_saver = node->create_service<spatio_temporal_voxel_layer::srv::SaveGrid>(
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  155 |     "save_grid", save_grid_callback, rmw_qos_profile_services_default, callback_group_);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/ros/jazzy/include/rclcpp_lifecycle/rclcpp_lifecycle/lifecycle_node.hpp:1126,
                 from /root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_grid.hpp:58,
                 from /root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp:54,
                 from /root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp:45:
/opt/ros/jazzy/include/rclcpp_lifecycle/rclcpp_lifecycle/lifecycle_node_impl.hpp:149:1: note: declared here
  149 | LifecycleNode::create_service(
      | ^~~~~~~~~~~~~
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp:344:63: warning: ‘typename rclcpp::Service<ServiceT>::SharedPtr rclcpp_lifecycle::LifecycleNode::create_service(const std::string&, CallbackT&&, const rmw_qos_profile_t&, rclcpp::CallbackGroup::SharedPtr) [with ServiceT = std_srvs::srv::SetBool; CallbackT = std::function<void(std::shared_ptr<rmw_request_id_s>, std::shared_ptr<std_srvs::srv::SetBool_Request_<std::allocator<void> > >, std::shared_ptr<std_srvs::srv::SetBool_Response_<std::allocator<void> > >)>&; typename rclcpp::Service<ServiceT>::SharedPtr = std::shared_ptr<rclcpp::Service<std_srvs::srv::SetBool> >; std::string = std::__cxx11::basic_string<char>; rmw_qos_profile_t = rmw_qos_profile_s; rclcpp::CallbackGroup::SharedPtr = std::shared_ptr<rclcpp::CallbackGroup>]’ is deprecated: use rclcpp::QoS instead of rmw_qos_profile_t [-Wdeprecated-declarations]
  344 |     auto server = node->create_service<std_srvs::srv::SetBool>(
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  345 |       toggle_topic, toggle_srv_callback, rmw_qos_profile_services_default, callback_group_);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/jazzy/include/rclcpp_lifecycle/rclcpp_lifecycle/lifecycle_node_impl.hpp:149:1: note: declared here
  149 | LifecycleNode::create_service(
      | ^~~~~~~~~~~~~
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp: In member function ‘void volume_grid::SpatioTemporalVoxelGrid::ClearFrustums(const std::vector<observation::MeasurementReading>&, std::unordered_set<volume_grid::occupany_cell>&)’:
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp:136:14: warning: ‘frustum’ may be used uninitialized [-Wmaybe-uninitialized]
  136 |       delete frustum;
      |              ^~~~~~~
/root/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp:125:25: note: ‘frustum’ declared here
  125 |     geometry::Frustum * frustum;
  ```