### PR TITLE
Sync changes with pcl conversions, message filter, nav2

### DIFF
--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -115,6 +115,7 @@ target_link_libraries(${library_name}
   tf2_sensor_msgs::tf2_sensor_msgs
   nav2_costmap_2d::nav2_costmap_2d_core
   laser_geometry::laser_geometry
+  pcl_conversions::pcl_conversions
 )
 
 # Get a linker error when there are undefined symbols

--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(message_filters REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(nav2_ros_common REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
@@ -116,6 +117,7 @@ target_link_libraries(${library_name}
   nav2_costmap_2d::nav2_costmap_2d_core
   laser_geometry::laser_geometry
   pcl_conversions::pcl_conversions
+  nav2_ros_common::nav2_ros_common
 )
 
 # Get a linker error when there are undefined symbols

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/depth_camera_frustum.hpp
@@ -84,7 +84,7 @@ private:
   #if VISUALIZE_FRUSTUM
   std::vector<Eigen::Vector3d> _frustum_pts;
   rclcpp::Node::SharedPtr _node;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr _frustum_pub;
+  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr _frustum_pub;
   #endif
 };
 

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -75,14 +75,13 @@
 #include "tf2_ros/message_filter.h"
 #include "message_filters/subscriber.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-#include "tf2/buffer_core.h"
 
 namespace spatio_temporal_voxel_layer
 {
 
 // conveniences for line lengths
 typedef std::vector<
-  std::shared_ptr<message_filters::SubscriberBase<rclcpp_lifecycle::LifecycleNode>>
+  std::shared_ptr<message_filters::SubscriberBase>
   >::iterator observation_subscribers_iter;
 typedef std::vector<std::shared_ptr<buffer::MeasurementBuffer>>::iterator observation_buffers_iter;
 
@@ -155,7 +154,7 @@ private:
     const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
     std::shared_ptr<std_srvs::srv::SetBool::Response> response,
     const std::shared_ptr<buffer::MeasurementBuffer> buffer,
-    const std::shared_ptr<message_filters::SubscriberBase<rclcpp_lifecycle::LifecycleNode>>
+    const std::shared_ptr<message_filters::SubscriberBase>
       & subcriber
     );
 
@@ -167,17 +166,17 @@ private:
     dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 
   laser_geometry::LaserProjection _laser_projector;
-  std::vector<std::shared_ptr<message_filters::SubscriberBase<rclcpp_lifecycle::LifecycleNode>>>
+  std::vector<std::shared_ptr<message_filters::SubscriberBase>>
     _observation_subscribers;
   std::vector<std::shared_ptr<tf2_ros::MessageFilterBase>> _observation_notifiers;
   std::vector<std::shared_ptr<buffer::MeasurementBuffer>> _observation_buffers;
   std::vector<std::shared_ptr<buffer::MeasurementBuffer>> _marking_buffers;
   std::vector<std::shared_ptr<buffer::MeasurementBuffer>> _clearing_buffers;
-  std::vector<rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr> _buffer_enabler_servers;
+  std::vector<nav2::ServiceServer<std_srvs::srv::SetBool>::SharedPtr> _buffer_enabler_servers;
 
   bool _publish_voxels, _mapping_mode, was_reset_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _voxel_pub;
-  rclcpp::Service<spatio_temporal_voxel_layer::srv::SaveGrid>::SharedPtr _grid_saver;
+  nav2::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _voxel_pub;
+  nav2::ServiceServer<spatio_temporal_voxel_layer::srv::SaveGrid>::SharedPtr _grid_saver;
   std::unique_ptr<rclcpp::Duration> _map_save_duration;
   rclcpp::Time _last_map_save_time;
   std::string _global_frame;

--- a/spatio_temporal_voxel_layer/package.xml
+++ b/spatio_temporal_voxel_layer/package.xml
@@ -32,6 +32,7 @@
   <depend>visualization_msgs</depend>
   <depend>openvdb_vendor</depend>
   <depend>libopenexr-dev</depend>
+  <depend>nav2_ros_common</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/spatio_temporal_voxel_layer/src/frustum_models/depth_camera_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/depth_camera_frustum.cpp
@@ -51,7 +51,7 @@ DepthCameraFrustum::DepthCameraFrustum(
   _valid_frustum = false;
   #if VISUALIZE_FRUSTUM
   _node = std::make_shared<rclcpp::Node>("frustum_publisher");
-  _frustum_pub = _node->create_publisher<visualization_msgs::msg::MarkerArray>("frustum", 10);
+  _frustum_pub = _node->create_publisher<visualization_msgs::msg::MarkerArray>("frustum", nav2::qos::StandardTopicQoS());
   rclcpp::sleep_for(std::chrono::milliseconds(500));
   #endif
   this->ComputePlaneNormals();

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -146,19 +146,16 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   auto sub_opt = rclcpp::SubscriptionOptions();
   sub_opt.callback_group = callback_group_;
 
-  auto pub_opt = rclcpp::PublisherOptions();
-  pub_opt.callback_group = callback_group_;
-
   if(_publish_voxels)
   {
     _voxel_pub = node->create_publisher<sensor_msgs::msg::PointCloud2>(
-      "voxel_grid", rclcpp::QoS(1), pub_opt);
+      "voxel_grid", nav2::qos::StandardTopicQoS(1), callback_group_);
   }
 
   auto save_grid_callback = std::bind(
     &SpatioTemporalVoxelLayer::SaveGridCallback, this, _1, _2, _3);
   _grid_saver = node->create_service<spatio_temporal_voxel_layer::srv::SaveGrid>(
-    "save_grid", save_grid_callback, rclcpp::SystemDefaultsQoS(), callback_group_);
+    "save_grid", save_grid_callback, callback_group_);
 
   _voxel_grid = std::make_unique<volume_grid::SpatioTemporalVoxelGrid>(
     node->get_clock(), _voxel_size, static_cast<double>(default_value_), _decay_model,
@@ -288,13 +285,12 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
       _clearing_buffers.push_back(_observation_buffers.back());
     }
 
-    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_sensor_data;
-    custom_qos_profile.depth = 50;
+    const auto custom_qos_profile = nav2::qos::SensorDataQoS(50);
 
     // create a callback for the topic
     if (data_type == "LaserScan") {
-      auto sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::LaserScan,
-          rclcpp_lifecycle::LifecycleNode>>(node, topic, custom_qos_profile, sub_opt);
+      auto sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::LaserScan>>(
+        node, topic, custom_qos_profile, sub_opt);
       sub->unsubscribe();
 
       std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>
@@ -321,8 +317,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
 
       _observation_notifiers.back()->setTolerance(rclcpp::Duration::from_seconds(0.05));
     } else if (data_type == "PointCloud2") {
-      auto sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2,
-          rclcpp_lifecycle::LifecycleNode>>(node, topic, custom_qos_profile, sub_opt);
+      auto sub = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
+        node, topic, custom_qos_profile, sub_opt);
       sub->unsubscribe();
 
       std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>
@@ -350,7 +346,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
       _observation_subscribers.back());
     std::string toggle_topic = source + "/toggle_enabled";
     auto server = node->create_service<std_srvs::srv::SetBool>(
-      toggle_topic, toggle_srv_callback, rclcpp::SystemDefaultsQoS(), callback_group_);
+      toggle_topic, toggle_srv_callback, callback_group_);
 
     _buffer_enabler_servers.push_back(server);
 
@@ -454,7 +450,7 @@ void SpatioTemporalVoxelLayer::BufferEnablerCallback(
   const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
   std::shared_ptr<std_srvs::srv::SetBool::Response> response,
   const std::shared_ptr<buffer::MeasurementBuffer> buffer,
-  const std::shared_ptr<message_filters::SubscriberBase<rclcpp_lifecycle::LifecycleNode>> &subcriber
+  const std::shared_ptr<message_filters::SubscriberBase> &subcriber
   )
 /*****************************************************************************/
 {


### PR DESCRIPTION
This pr sync changes with pcl conversions, message filter, nav2

For pcl_conversions: my last pr #329 is not working properly with the latest release of pcl conversions, it will reported xxx.h not found when compiling, it works with the older release though, I am not entirely sure why 

For message filters: mostly the SubscriberBase part

For nav2: related to https://github.com/ros-navigation/navigation2/pull/5288