### PR TITLE
Fix: Resolve undefined symbol linker errors on macOS

### DIFF
--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -124,7 +124,12 @@ target_link_libraries(${library_name}
 )
 
 # Get a linker error when there are undefined symbols
-target_link_options(${library_name} PRIVATE -Wl,--no-undefined)
+if(APPLE)
+  # macOS linker flag for AppleClang
+  target_link_options(${library_name} PRIVATE -Wl,-undefined,error)
+else()
+  target_link_options(${library_name} PRIVATE -Wl,--no-undefined)
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
This pull request addresses a linker error that prevented the project from building on macOS.

The original `target_link_options` command used the `--no-undefined` flag, which is specific to the `GNU` linker used on Linux. This flag is not recognized by the macOS linker `(ld64),` causing the build to fail.

To resolve this, the linker options are now set conditionally:

- On Linux, the build continues to use the standard `-Wl,--no-undefined` flag to catch undefined symbols at link time.

- On macOS, the equivalent `-Wl,-undefined,error` flag is used, which enforces the same behavior on Apple platforms.


Fyi @traversaro. :)