### PR TITLE
Persistent mode fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Note: We supply two PCL filters within STVL to massage the data to lower compute
 rgbd_obstacle_layer:
   enabled:               true
   voxel_decay:           20     #seconds if linear, e^n if exponential
-  decay_model:           0      #0=linear, 1=exponential, -1=persistent
+  decay_model:           0      #0=linear, 1=exponential, 2=persistent
   voxel_size:            0.05   #meters
   track_unknown_space:   true   #default space is unknown
   observation_persistence: 0.0  #seconds

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -348,7 +348,7 @@ double SpatioTemporalVoxelGrid::GetTemporalClearingDuration(
   } else if (_decay_model == 1) {  // Exponential
     return _voxel_decay * std::exp(-time_delta);
   }
-  return _voxel_decay;  // PERSISTENT
+  return std::numeric_limits<double>::max();  // PERSISTENT
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Refer: Issue #339

Fixes:
1. The Persistent mode value was incorrectly documented as -1 in the README. Updated the documentation to the correct value which is 2.
2. GetTemporalClearingDuration() previously returned the voxel_decay parameter value. In Persistent mode, when voxel_decay is unset, this function returned -1 (default), causing voxels to be cleared immediately. This resulted in no objects being displayed in the costmap. The function now returns std::numeric_limits<double>::max() in Persistent mode.