### PR TITLE
enable QoS policy overriding for publishers and subscribers

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -142,9 +142,11 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
 
   auto sub_opt = rclcpp::SubscriptionOptions();
   sub_opt.callback_group = callback_group_;
+  sub_opt.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
 
   auto pub_opt = rclcpp::PublisherOptions();
   sub_opt.callback_group = callback_group_;
+  pub_opt.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
 
   if(_publish_voxels)
   {

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -142,11 +142,21 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
 
   auto sub_opt = rclcpp::SubscriptionOptions();
   sub_opt.callback_group = callback_group_;
-  sub_opt.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  sub_opt.qos_overriding_options = rclcpp::QosOverridingOptions(
+    {rclcpp::QosPolicyKind::Reliability,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Durability}
+  );
 
   auto pub_opt = rclcpp::PublisherOptions();
   sub_opt.callback_group = callback_group_;
-  pub_opt.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  pub_opt.qos_overriding_options = rclcpp::QosOverridingOptions(
+    {rclcpp::QosPolicyKind::Reliability,
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Durability}
+  );
 
   if(_publish_voxels)
   {


### PR DESCRIPTION
Add QosOverridingOptions::with_default_policies() to both publisher and
subscription options. This allows users to override QoS settings via
ROS 2 parameters (e.g., from a YAML file), enabling runtime tuning of
reliability, durability, and history depth without recompilation.

Useful for adapting to different network conditions or deployment
scenarios.