### PR TITLE
Fix RHEL buildfarm issues

### DIFF
--- a/openvdb_vendor/package.xml
+++ b/openvdb_vendor/package.xml
@@ -23,10 +23,13 @@
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
 
+  <depend>bzip2</depend>
   <depend>libblosc-dev</depend>
   <depend>libboost-iostreams-dev</depend>
   <depend>libboost-thread-dev</depend>
+  <depend>liblzma-dev</depend>
   <depend condition="$ROS_DISTRO != humble and $ROS_DISTRO != iron">libopenvdb-dev</depend>
+  <depend>libzstd-dev</depend>
   <depend>tbb</depend>
   <depend>zlib</depend>
 


### PR DESCRIPTION
Cleaning up my mailbox..

https://build.ros2.org/job/Kbin_rhel_el964__openvdb_vendor__rhel_9_x86_64__binary/52/console

> DEBUG: /usr/bin/ld: cannot find -lbz2
DEBUG: /usr/bin/ld: cannot find -llzma
DEBUG: /usr/bin/ld: cannot find -lzstd