### PR TITLE
Invalidate costmap (current_ = false) on dynamic parameter updates

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -854,6 +854,9 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
               buffer->Lock();
               buffer->SetMinObstacleHeight(parameter.as_double());
               buffer->Unlock();
+
+              boost::unique_lock<mutex_t> cm_lock(*getMutex());
+              current_ = false;
             }
           }
         } else if (name == name_ + "." + source + "." + "max_obstacle_height") {
@@ -862,6 +865,9 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
               buffer->Lock();
               buffer->SetMaxObstacleHeight(parameter.as_double());
               buffer->Unlock();
+
+              boost::unique_lock<mutex_t> cm_lock(*getMutex());
+              current_ = false;
             }
           }
         } else if (name == name_ + "." + source + "." + "min_z") {
@@ -944,12 +950,18 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
           }
         }
         enabled_ = enable;
+
+        boost::unique_lock<mutex_t> cm_lock(*getMutex());
+        current_ = false;
       }
     }
 
     if (type == ParameterType::PARAMETER_INTEGER) {
       if (name == name_ + "." + "mark_threshold") {
         _mark_threshold = parameter.as_int();
+
+        boost::unique_lock<mutex_t> cm_lock(*getMutex());
+        current_ = false;
       }
     }
   }


### PR DESCRIPTION
## Summary
This PR invalidates the `SpatioTemporalVoxelLayer` costmap (`current_ = false`) when key dynamic parameters are changed at runtime, ensuring the layer is recomputed and does not keep serving stale data.

## Changes
When the following parameters are updated, the layer now sets `current_ = false` under the costmap mutex:

- `min_obstacle_height`
- `max_obstacle_height`
- `mark_threshold`
- `enabled` 

Each update includes:

```cpp
boost::unique_lock<mutex_t> cm_lock(*getMutex());
current_ = false;