### PR TITLE
added obstruction polygons to 3d lidar frustrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ An example fully-described configuration is shown below.
 
 Note: We supply two PCL filters within STVL to massage the data to lower compute overhead. STVL has an approximate voxel filter to make the data more sparse if very dense. It also has a passthrough filter to limit processing data within the valid minimum to maximum height bounds. The voxel filter is recommended if it lowers CPU overhead, otherwise, passthrough filter. No filter is also available if you pre-process your data or are not interested in performance optimizations. 
 
-```
+```yaml
 rgbd_obstacle_layer:
   enabled:               true
   voxel_decay:           20     #seconds if linear, e^n if exponential
@@ -150,22 +150,29 @@ rgbd_obstacle_layer:
 ```
 More configuration samples are included in the example folder, including a 3D lidar one.
 
+### Obstruction polygons for voxel retention
+
 In case you want to use the 3D lidar model with defined obstructions (e.g., robot body parts blocking the sensor's FOV), you can add the `obstruction_polygons` parameter. This prevents frustum clearing in the specified azimuth/elevation regions, preserving voxels behind blind spots:
 
 ```yaml
   lidar1_clear:
+    ...
     data_type: PointCloud2
     topic: /lidar/points
     marking: false
     clearing: true
     model_type: 1                #3D Lidar
-    horizontal_fov_angle: 6.28   #radians, full circle
-    vertical_fov_angle: 0.52     #radians
-    decay_acceleration: 5.0
+    horizontal_fov_angle: 6.28   #full circle
+    vertical_fov_angle: 1.57     #90 deg
+    obstacle_range: 20.0         #should be large enough to clear further than marking range, and further than voxels that may have been retained behind obstructions while robot moved.
     obstruction_polygons: "[[0.8,-0.2, 1.2,-0.2, 1.2,0.1, 0.8,0.1], [3.5,-0.3, 4.0,-0.3, 4.0,0.0, 3.5,0.0]]"
 ```
 
 Each inner bracket `[az1,el1, az2,el2, ...]` defines one convex polygon (minimum 3 vertices, azimuth in [0, 2π] radians, elevation in [-π/2, π/2] radians). If empty or unset, behavior is identical to the original STVL. Only applies to `model_type: 1`.
+
+<img width="340" height="314" alt="stvl_obstruction_polygon_retention" src="https://github.com/user-attachments/assets/e0828595-86f9-4935-b21d-989995b964fe" />
+
+_An example of 3d lidar with obstruction from forklift mast. The voxels in the obstructed FOV (orange) are not cleared, but retained for voxel_decay seconds_
 
 ### local/global_costmap_params.yaml
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ rgbd_obstacle_layer:
 ```
 More configuration samples are included in the example folder, including a 3D lidar one.
 
-### Obstruction polygons for voxel retention
+### Obstruction polygons for voxel retention in blind spots
+
+<img width="340" height="314" alt="stvl_obstruction_polygon_retention" src="https://github.com/user-attachments/assets/e0828595-86f9-4935-b21d-989995b964fe" />
+
+_An example of 3d lidar with obstruction from forklift mast. The voxels in the obstructed FOV (orange) are not cleared, but retained for voxel_decay seconds_
 
 In case you want to use the 3D lidar model with defined obstructions (e.g., robot body parts blocking the sensor's FOV), you can add the `obstruction_polygons` parameter. This prevents frustum clearing in the specified azimuth/elevation regions, preserving voxels behind blind spots:
 
@@ -170,9 +174,13 @@ In case you want to use the 3D lidar model with defined obstructions (e.g., robo
 
 Each inner bracket `[az1,el1, az2,el2, ...]` defines one convex polygon (minimum 3 vertices, azimuth in [0, 2π] radians, elevation in [-π/2, π/2] radians). If empty or unset, behavior is identical to the original STVL. Only applies to `model_type: 1`.
 
-<img width="340" height="314" alt="stvl_obstruction_polygon_retention" src="https://github.com/user-attachments/assets/e0828595-86f9-4935-b21d-989995b964fe" />
+#### Edges are great-circle arcs, not az/el straight lines
 
-_An example of 3d lidar with obstruction from forklift mast. The voxels in the obstructed FOV (orange) are not cleared, but retained for voxel_decay seconds_
+The vertices will be represented as 3D *directions* from the sensor into the world. Each edge is the geodesic between two of them. This means in the polygon is **not** the flat box in (azimuth, elevation) that the numbers suggest. The edges will be bent according to  the following figure. Also, edges longer than pi will "flip" to cross the 0/2pi seam, because the arc is represented by the shortest distance between vertices.
+
+<img width="2247" height="957" alt="obstruction_polygon_projection" src="https://github.com/user-attachments/assets/32c2919d-0983-493d-91b7-dd8dd22a746a" />
+
+**Tip:** When you want to have a large azimuth polygon edge, split it into multiple smaller polygons to avoid bowing and flipping. Don't use multiple smaller azimuth edges in the same polygon, this will likely cause non convexity.
 
 ### local/global_costmap_params.yaml
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ rgbd_obstacle_layer:
 ```
 More configuration samples are included in the example folder, including a 3D lidar one.
 
+In case you want to use the 3D lidar model with defined obstructions (e.g., robot body parts blocking the sensor's FOV), you can add the `obstruction_polygons` parameter. This prevents frustum clearing in the specified azimuth/elevation regions, preserving voxels behind blind spots:
+
+```yaml
+  lidar1_clear:
+    data_type: PointCloud2
+    topic: /lidar/points
+    marking: false
+    clearing: true
+    model_type: 1                #3D Lidar
+    horizontal_fov_angle: 6.28   #radians, full circle
+    vertical_fov_angle: 0.52     #radians
+    decay_acceleration: 5.0
+    obstruction_polygons: "[[0.8,-0.2, 1.2,-0.2, 1.2,0.1, 0.8,0.1], [3.5,-0.3, 4.0,-0.3, 4.0,0.0, 3.5,0.0]]"
+```
+
+Each inner bracket `[az1,el1, az2,el2, ...]` defines one convex polygon (minimum 3 vertices, azimuth in [0, 2π] radians, elevation in [-π/2, π/2] radians). If empty or unset, behavior is identical to the original STVL. Only applies to `model_type: 1`.
+
 ### local/global_costmap_params.yaml
 
 Add this plugin to your costmap params file. 

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -57,7 +57,8 @@ class ThreeDimensionalLidarFrustum : public Frustum
 public:
   ThreeDimensionalLidarFrustum(
     const double & vFOV, const double & vFOVPadding,
-    const double & hFOV, const double & min_dist, const double & max_dist);
+    const double & hFOV, const double & min_dist, const double & max_dist,
+    std::shared_ptr<geometry::ObstructionFilter> obstruction_filter = nullptr);
   virtual ~ThreeDimensionalLidarFrustum(void);
 
   // Does nothing in 3D lidar model
@@ -69,9 +70,6 @@ public:
   // set pose of 3d lidar in global space
   virtual void SetPosition(const geometry_msgs::msg::Point & origin);
   virtual void SetOrientation(const geometry_msgs::msg::Quaternion & quat);
-
-  // Set obstruction polygons (blind spots in sensor-local angular space)
-  void SetObstructionFilter(std::shared_ptr<geometry::ObstructionFilter> filter);
 
 private:
   // utils to find useful frustum metadata

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -84,9 +84,9 @@ private:
   // externally set postion and orientation of sensor in global space
   Eigen::Vector3d _position;
   Eigen::Quaterniond _orientation;
-  // computed transform matrices to apply to voxels during clearing
-  Eigen::Matrix3d _rotation;
-  Eigen::Vector3d _translation;
+  // inverse of the pose above, precomputed once to map voxels into sensor-local space
+  Eigen::Matrix3d _global_to_sensor_rotation;
+  Eigen::Vector3d _global_to_sensor_translation;
   bool _valid_frustum;
   bool _full_hFOV;
   std::shared_ptr<geometry::ObstructionFilter> _obstruction_filter;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -42,8 +42,11 @@
 
 // M_PI
 #include <cmath>
+#include <vector>
+#include <memory>
 // STVL
 #include "spatio_temporal_voxel_layer/frustum_models/frustum.hpp"
+#include "spatio_temporal_voxel_layer/obstruction_polygons.hpp"
 
 namespace geometry
 {
@@ -67,6 +70,10 @@ public:
   virtual void SetPosition(const geometry_msgs::msg::Point & origin);
   virtual void SetOrientation(const geometry_msgs::msg::Quaternion & quat);
 
+  // Set obstruction polygons (blind spots in sensor-local angular space)
+  void SetObstructionPolygons(
+    std::shared_ptr<std::vector<ConvexPolygon2D>> polygons);
+
 private:
   // utils to find useful frustum metadata
   double Dot(const VectorWithPt3D &, const openvdb::Vec3d &) const;
@@ -82,6 +89,7 @@ private:
   Eigen::Quaterniond _orientation_conjugate;
   bool _valid_frustum;
   bool _full_hFOV;
+  std::shared_ptr<std::vector<ConvexPolygon2D>> _obstruction_polygons;
 };
 
 }  // namespace geometry

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -90,6 +90,7 @@ private:
   bool _valid_frustum;
   bool _full_hFOV;
   std::shared_ptr<std::vector<ConvexPolygon2D>> _obstruction_polygons;
+  ObstructionField _obstruction_field;
 };
 
 }  // namespace geometry

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -71,8 +71,7 @@ public:
   virtual void SetOrientation(const geometry_msgs::msg::Quaternion & quat);
 
   // Set obstruction polygons (blind spots in sensor-local angular space)
-  void SetObstructionFilter(
-    std::shared_ptr<geometry::ObstructionFilter> filter);
+  void SetObstructionFilter(std::shared_ptr<geometry::ObstructionFilter> filter);
 
 private:
   // utils to find useful frustum metadata
@@ -84,9 +83,12 @@ private:
   double _min_d_squared, _max_d_squared;
   double _tan_vFOVhalf;
   double _tan_vFOVhalf_squared;
+  // externally set postion and orientation of sensor in global space
   Eigen::Vector3d _position;
   Eigen::Quaterniond _orientation;
-  Eigen::Quaterniond _orientation_conjugate;
+  // computed transform matrices to apply to voxels during clearing
+  Eigen::Matrix3d _rotation;
+  Eigen::Vector3d _translation;
   bool _valid_frustum;
   bool _full_hFOV;
   std::shared_ptr<geometry::ObstructionFilter> _obstruction_filter;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -71,8 +71,8 @@ public:
   virtual void SetOrientation(const geometry_msgs::msg::Quaternion & quat);
 
   // Set obstruction polygons (blind spots in sensor-local angular space)
-  void SetObstructionPolygons(
-    std::shared_ptr<std::vector<ConvexPolygon2D>> polygons);
+  void SetObstructionFilter(
+    std::shared_ptr<geometry::ObstructionFilter> filter);
 
 private:
   // utils to find useful frustum metadata
@@ -89,8 +89,7 @@ private:
   Eigen::Quaterniond _orientation_conjugate;
   bool _valid_frustum;
   bool _full_hFOV;
-  std::shared_ptr<std::vector<ConvexPolygon2D>> _obstruction_polygons;
-  ObstructionField _obstruction_field;
+  std::shared_ptr<geometry::ObstructionFilter> _obstruction_filter;
 };
 
 }  // namespace geometry

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -136,6 +136,8 @@ public:
   void SetVerticalFovPadding(const double & vertical_fov_padding);
   void SetHorizontalFovAngle(const double & horizontal_fov_angle);
   void SetVerticalFovAngle(const double & vertical_fov_angle);
+  void SetObstructionPolygons(
+    std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> polygons);
 
   // State knoweldge if sensors are operating as expected
   bool UpdatedAtExpectedRate(void) const;
@@ -165,6 +167,7 @@ private:
   int _voxel_min_points;
   bool _clear_buffer_after_reading, _enabled;
   ModelType _model_type;
+  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> _obstruction_polygons;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_;
 };

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -136,8 +136,8 @@ public:
   void SetVerticalFovPadding(const double & vertical_fov_padding);
   void SetHorizontalFovAngle(const double & horizontal_fov_angle);
   void SetVerticalFovAngle(const double & vertical_fov_angle);
-  void SetObstructionPolygons(
-    std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> polygons);
+  void SetObstructionFilter(
+    std::shared_ptr<geometry::ObstructionFilter> filter);
 
   // State knoweldge if sensors are operating as expected
   bool UpdatedAtExpectedRate(void) const;
@@ -167,7 +167,7 @@ private:
   int _voxel_min_points;
   bool _clear_buffer_after_reading, _enabled;
   ModelType _model_type;
-  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> _obstruction_polygons;
+  std::shared_ptr<geometry::ObstructionFilter> _obstruction_filter;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_;
 };

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
@@ -116,7 +116,7 @@ struct MeasurementReading
     _clearing(obs._clearing),
     _decay_acceleration(obs._decay_acceleration),
     _model_type(obs._model_type),
-    _obstruction_polygons(obs._obstruction_polygons)
+    _obstruction_filter(obs._obstruction_filter)
   {
   }
 
@@ -127,7 +127,7 @@ struct MeasurementReading
   double _vertical_fov_in_rad, _vertical_fov_padding_in_m, _horizontal_fov_in_rad;
   double _marking, _clearing, _decay_acceleration;
   ModelType _model_type;
-  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> _obstruction_polygons;
+  std::shared_ptr<geometry::ObstructionFilter> _obstruction_filter;
 };
 
 }  // namespace observation

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
@@ -41,11 +41,15 @@
 #define SPATIO_TEMPORAL_VOXEL_LAYER__MEASUREMENT_READING_H_
 
 #include <memory>
+#include <vector>
 
 // msgs
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
+
+// obstruction polygons
+#include "spatio_temporal_voxel_layer/obstruction_polygons.hpp"
 
 enum ModelType
 {
@@ -111,7 +115,8 @@ struct MeasurementReading
     _marking(obs._marking),
     _clearing(obs._clearing),
     _decay_acceleration(obs._decay_acceleration),
-    _model_type(obs._model_type)
+    _model_type(obs._model_type),
+    _obstruction_polygons(obs._obstruction_polygons)
   {
   }
 
@@ -122,6 +127,7 @@ struct MeasurementReading
   double _vertical_fov_in_rad, _vertical_fov_padding_in_m, _horizontal_fov_in_rad;
   double _marking, _clearing, _decay_acceleration;
   ModelType _model_type;
+  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> _obstruction_polygons;
 };
 
 }  // namespace observation

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -39,13 +39,13 @@
 #ifndef SPATIO_TEMPORAL_VOXEL_LAYER__OBSTRUCTION_POLYGONS_HPP_
 #define SPATIO_TEMPORAL_VOXEL_LAYER__OBSTRUCTION_POLYGONS_HPP_
 
-#include <vector>
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
-#include <algorithm>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -58,7 +58,10 @@ struct SphericalPoint
   double elevation;  // radians
 };
 
-struct Vec3D { double x, y, z; };
+struct Vec3D
+{
+  double x, y, z;
+};
 
 /**
  * @brief A convex polygon defined in (azimuth, elevation) space with precomputed
@@ -108,9 +111,8 @@ struct ConvexPolygon2D
       normals[i].z = dirs[i].x * dirs[j].y - dirs[i].y * dirs[j].x;
 
       // Check for degenerate edge (coincident vertices)
-      double len_sq = normals[i].x * normals[i].x +
-                      normals[i].y * normals[i].y +
-                      normals[i].z * normals[i].z;
+      double len_sq =
+        normals[i].x * normals[i].x + normals[i].y * normals[i].y + normals[i].z * normals[i].z;
 
       constexpr double kMinEdgeNormSquared = 1e-12;  // reject edges < ~0.001° apart
       if (len_sq < kMinEdgeNormSquared) {
@@ -127,9 +129,8 @@ struct ConvexPolygon2D
     }
 
     // flip normals if pointing outward (dot product with centroid < 0)
-    double test_dot = normals[0].x * centroid.x +
-                      normals[0].y * centroid.y +
-                      normals[0].z * centroid.z;
+    double test_dot =
+      normals[0].x * centroid.x + normals[0].y * centroid.y + normals[0].z * centroid.z;
     if (test_dot < 0.0) {
       for (auto & norm : normals) {
         norm.x = -norm.x;
@@ -143,9 +144,8 @@ struct ConvexPolygon2D
     constexpr double kConvexEps = 1e-9;  // tolerance for vertices lying on an edge's line
     for (size_t i = 0; i < n; ++i) {
       for (size_t k = 0; k < n; ++k) {
-        double side = normals[i].x * dirs[k].x +
-                      normals[i].y * dirs[k].y +
-                      normals[i].z * dirs[k].z;
+        double side =
+          normals[i].x * dirs[k].x + normals[i].y * dirs[k].y + normals[i].z * dirs[k].z;
         if (side < -kConvexEps) {
           return false;  // non-convex polygon: reject rather than mis-test
         }
@@ -178,8 +178,7 @@ struct ConvexPolygon2D
  * @return vector of valid, precomputed polygons
  */
 inline std::vector<ConvexPolygon2D> validatePolygons(
-  const std::vector<ConvexPolygon2D> & input,
-  const rclcpp::Logger & logger)
+  const std::vector<ConvexPolygon2D> & input, const rclcpp::Logger & logger)
 {
   std::vector<ConvexPolygon2D> valid;
   valid.reserve(input.size());
@@ -187,10 +186,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
   for (size_t idx = 0; idx < input.size(); ++idx) {
     auto poly = input[idx];
     if (poly.vertices.size() < 3) {
-      RCLCPP_WARN(
-        logger,
-        "Obstruction polygon %zu has < 3 vertices, skipping.",
-        idx);
+      RCLCPP_WARN(logger, "Obstruction polygon %zu has < 3 vertices, skipping.", idx);
       continue;
     }
 
@@ -203,10 +199,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
       }
     }
     if (has_nan) {
-      RCLCPP_WARN(
-        logger,
-        "Obstruction polygon %zu has NaN/inf vertices, skipping.",
-        idx);
+      RCLCPP_WARN(logger, "Obstruction polygon %zu has NaN/inf vertices, skipping.", idx);
       continue;
     }
 
@@ -230,8 +223,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
     if (!poly.precompute()) {
       RCLCPP_ERROR(
         logger,
-        "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.",
-        idx);
+        "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.", idx);
       continue;
     }
 
@@ -246,8 +238,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
  * Takes raw cartesian direction (x, y, z) from sensor frame.
  */
 inline bool isInsideAnyObstruction(
-  const std::vector<ConvexPolygon2D> & polygons,
-  double x, double y, double z)
+  const std::vector<ConvexPolygon2D> & polygons, double x, double y, double z)
 {
   for (const auto & poly : polygons) {
     if (poly.isInside(x, y, z)) {
@@ -276,7 +267,7 @@ struct ObstructionField
   };
   std::vector<Span> polygons;
 
-  bool empty() const {return polygons.empty();}
+  bool empty() const { return polygons.empty(); }
 };
 
 /**
@@ -297,8 +288,7 @@ inline double polygonAngularArea(const ConvexPolygon2D & p)
 /**
  * @brief Convert validated/precomputed polygons to flat SoA and sort by angular area
  */
-inline ObstructionField flattenAndSortPolygons(
-  const std::vector<ConvexPolygon2D> & polygons)
+inline ObstructionField flattenAndSortPolygons(const std::vector<ConvexPolygon2D> & polygons)
 {
   ObstructionField field;
 
@@ -342,15 +332,13 @@ inline ObstructionField flattenAndSortPolygons(
 /**
  * @brief Check if a 3D direction falls inside any obstruction polygon
  */
-inline bool isInsideAnyObstruction(
-  const ObstructionField & field,
-  float x, float y, float z)
+inline bool isInsideAnyObstruction(const ObstructionField & field, float x, float y, float z)
 {
-  const float* nx = field.nx.data();
-  const float* ny = field.ny.data();
-  const float* nz = field.nz.data();
+  const float * nx = field.nx.data();
+  const float * ny = field.ny.data();
+  const float * nz = field.nz.data();
 
-  for (const auto& span : field.polygons) {
+  for (const auto & span : field.polygons) {
     const uint32_t end = span.start + span.count;
     int any_negative = 0;
     for (uint32_t i = span.start; i < end; ++i) {
@@ -373,17 +361,16 @@ inline bool isInsideAnyObstruction(
  * @return vector of parsed (unvalidated) polygons
  */
 inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
-  const std::string & input,
-  const rclcpp::Logger & logger)
+  const std::string & input, const rclcpp::Logger & logger)
 {
   std::vector<ConvexPolygon2D> polygons;
 
   // Find the outer brackets
   size_t outer_start = input.find('[');
   size_t outer_end = input.rfind(']');
-  if (outer_start == std::string::npos || outer_end == std::string::npos ||
-    outer_end <= outer_start)
-  {
+  if (
+    outer_start == std::string::npos || outer_end == std::string::npos ||
+    outer_end <= outer_start) {
     RCLCPP_WARN(logger, "Obstruction polygons string has invalid format.");
     return polygons;
   }
@@ -411,13 +398,14 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
     while (std::getline(ss, token, ',')) {
       // Trim whitespace
       size_t start = token.find_first_not_of(" \t");
-      if (start == std::string::npos) {continue;}
+      if (start == std::string::npos) {
+        continue;
+      }
       try {
         values.push_back(std::stod(token.substr(start)));
       } catch (const std::exception &) {
         RCLCPP_WARN(
-          logger, "Obstruction polygon %d: failed to parse value '%s'.",
-          poly_idx, token.c_str());
+          logger, "Obstruction polygon %d: failed to parse value '%s'.", poly_idx, token.c_str());
       }
     }
 
@@ -429,8 +417,7 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
       polygons.push_back(std::move(poly));
     } else if (!values.empty()) {
       RCLCPP_WARN(
-        logger,
-        "Obstruction polygon %d needs >= 6 values (3 x/y pairs), got %zu. Skipping.",
+        logger, "Obstruction polygon %d needs >= 6 values (3 x/y pairs), got %zu. Skipping.",
         poly_idx, values.size());
     }
 
@@ -449,11 +436,9 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
  *
  * For STVL use, x=azimuth (rad), y=elevation (rad).
  */
-template<typename NodeT>
+template <typename NodeT>
 std::vector<ConvexPolygon2D> parseObstructionPolygonsFromParams(
-  NodeT node,
-  const std::string & param_prefix,
-  const rclcpp::Logger & logger)
+  NodeT node, const std::string & param_prefix, const rclcpp::Logger & logger)
 {
   std::string param_name = param_prefix + ".obstruction_polygons";
   std::string polygons_str;
@@ -470,9 +455,7 @@ std::vector<ConvexPolygon2D> parseObstructionPolygonsFromParams(
 
   if (!polygons.empty()) {
     RCLCPP_INFO(
-      logger,
-      "Parsed %zu obstruction polygon(s) for %s",
-      polygons.size(), param_prefix.c_str());
+      logger, "Parsed %zu obstruction polygon(s) for %s", polygons.size(), param_prefix.c_str());
   }
 
   return validatePolygons(polygons, logger);

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -71,21 +72,6 @@ struct SphericalPoint
 };
 using AngularPolygon = std::vector<SphericalPoint>;
 
-/**
- * @brief Angular area of a 2D (azimuth, elevation) polygon via the shoelace formula.
- */
-inline double angularArea(const AngularPolygon & vertices)
-{
-  const size_t n = vertices.size();
-  double area2 = 0.0;
-  for (size_t i = 0; i < n; ++i) {
-    const auto & v0 = vertices[i];
-    const auto & v1 = vertices[(i + 1) % n];
-    area2 += v0.azimuth * v1.elevation - v1.azimuth * v0.elevation;
-  }
-  return std::fabs(area2) * 0.5;
-}
-
 // ---------------------------------------------------------------------------
 // 3D / directional domain
 // ---------------------------------------------------------------------------
@@ -96,10 +82,45 @@ struct Vec3D
 };
 
 /**
+ * @brief Solid angle covered by a spherical polygon, from its edge-plane normals.
+ *
+ * Girard's theorem: a spherical polygon's interior angles exceed the flat (n-2)*pi by exactly
+ * the area it covers on the unit sphere.
+ * @param normals unit edge-plane normals, one per edge, in vertex order
+ * @return steradians covered; 2*pi for a hemisphere, and 0 for a polygon enclosing nothing
+ */
+inline double solidAngleFromNormals(const std::vector<Vec3D> & normals)
+{
+  const size_t n = normals.size();
+  double exterior_angle_sum = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    const size_t j = (i + 1) % n;  // index of next edge
+    const double dot =
+      normals[i].x * normals[j].x + normals[i].y * normals[j].y + normals[i].z * normals[j].z;
+    // clamp because rounding can push the dot just past +-1, where acos is undefined
+    exterior_angle_sum += std::acos(std::clamp(dot, -1.0, 1.0));
+  }
+  return 2.0 * M_PI - exterior_angle_sum;
+}
+
+/**
  * @brief The 3D/directional counterpart of the 2D angular polygon: a convex
  *        polyhedral cone through the origin, defined as the intersection of
  *        great-circle half-planes (one per polygon edge). Used for
  *        point-in-polygon tests on directions instead of points.
+ *
+ * Edges are geodesics, so each one takes the SHORT way round the sphere. Two
+ * consequences:
+ *   - An edge whose azimuth step exceeds pi sweeps the other way, across 0/2pi,
+ *     so the cone covers the complement of the intended band.
+ *   - A geodesic between two vertices at equal elevation bows away from the
+ *     equator. A band drawn 0.1 rad tall (elevation) over 3.0 rad of azimuth
+ *     actually reaches el 0.96.
+ * Keep each edge's azimuth step small and slice a wide blind spot into several
+ * polygons; the filter is a union, so slicing costs nothing.
+ *
+ * Size is measured on the sphere, as the solid angle the cone covers, never as a
+ * flat area in the az/el chart.
  */
 class ConvexCone
 {
@@ -107,9 +128,9 @@ public:
   /**
    * @brief Project angular (az/el) vertices onto the unit sphere and compute the
    *        great-circle half-plane normal for each edge.
-   * @return the resulting cone
-   * @throws std::runtime_error if the vertices are too few, produce a degenerate edge, or
-   *         are not spherically convex.
+   * @return the resulting cone, carrying the solid angle it covers
+   * @throws std::runtime_error if the vertices do not describe a usable cone, with the
+   *         specific fault in the message
    */
   static ConvexCone fromAngularVertices(const AngularPolygon & vertices)
   {
@@ -137,7 +158,7 @@ public:
       normals[i].y = dirs[i].z * dirs[j].x - dirs[i].x * dirs[j].z;
       normals[i].z = dirs[i].x * dirs[j].y - dirs[i].y * dirs[j].x;
 
-      // Check for degenerate edge (coincident vertices)
+      // Check for degenerate edge (vertices coincident or 180 deg apart)
       const double len_sq =
         normals[i].x * normals[i].x + normals[i].y * normals[i].y + normals[i].z * normals[i].z;
 
@@ -145,7 +166,7 @@ public:
       if (len_sq < kMinEdgeNormSquared) {
         throw std::runtime_error(
                 "has a degenerate edge between vertices " + std::to_string(i) + " and " +
-                std::to_string(j) + ": the two directions are coincident");
+                std::to_string(j) + ": the two directions are coincident or 180 deg apart");
       }
 
       // Normalize to ensure equal application of kConvexEps below.
@@ -155,18 +176,53 @@ public:
       normals[i].z /= len;
     }
 
-    // Determine orientation: centroid direction should be on inside of all half-planes
+    // Determine orientation: the centroid direction should be on the inside of all
+    // half-planes. That only holds when the vertices all fit inside one hemisphere -
+    // otherwise their sum cancels out and there is no interior direction to reference.
     Vec3D centroid{0.0, 0.0, 0.0};
     for (const auto & d : dirs) {
       centroid.x += d.x;
       centroid.y += d.y;
       centroid.z += d.z;
     }
+    constexpr double kMinCentroidNorm = 1e-9;
+    const double centroid_norm =
+      std::sqrt(centroid.x * centroid.x + centroid.y * centroid.y + centroid.z * centroid.z);
+    if (centroid_norm < kMinCentroidNorm) {
+      throw std::runtime_error(
+              "has vertex directions that cancel out, so it wraps the sphere instead of bounding"
+              " a patch; slice it into several smaller polygons");
+    }
+    centroid.x /= centroid_norm;
+    centroid.y /= centroid_norm;
+    centroid.z /= centroid_norm;
 
-    // flip normals if pointing outward (dot product with centroid < 0) winding detection
-    const double test_dot =
-      normals[0].x * centroid.x + normals[0].y * centroid.y + normals[0].z * centroid.z;
-    if (test_dot < 0.0) {
+    // Winding detection. Normals and centroid are both unit length, so each dot is the sine
+    // of the centroid's angular distance from that edge's plane. Find extremes.
+    constexpr double kInteriorEps = 1e-9;  // radians off-plane
+    double min_dot = std::numeric_limits<double>::max();
+    double max_dot = std::numeric_limits<double>::lowest();
+    for (const auto & norm : normals) {
+      const double dot = norm.x * centroid.x + norm.y * centroid.y + norm.z * centroid.z;
+      min_dot = std::min(min_dot, dot);
+      max_dot = std::max(max_dot, dot);
+    }
+
+    if (max_dot <= kInteriorEps && min_dot >= -kInteriorEps) {
+      throw std::runtime_error(
+              "is degenerate: every vertex lies on one great circle through the sensor, so it"
+              " encloses no solid angle at all");
+    }
+
+    // if minimum dot product is still positive, all normals must point inwards
+    const bool inward = min_dot > kInteriorEps;
+
+    // Flip unless the normals already point inward, which isObstructed relies on. A convex
+    // polygon's normals are all inward or all outward together, so one global negation fixes
+    // a reversed polygon if its convex.
+    // Inconsistent winding has no right answer; flipping is arbitrary and the convexity check
+    // below rejects it.
+    if (!inward) {
       for (auto & norm : normals) {
         norm.x = -norm.x;
         norm.y = -norm.y;
@@ -186,20 +242,46 @@ public:
         if (side < -kConvexEps) {
           throw std::runtime_error(
                   "is not spherically convex: vertex " + std::to_string(k) +
-                  " lies outside the edge starting at vertex " + std::to_string(i));
+                  " lies outside the edge starting at vertex " + std::to_string(i) +
+                  ". Each polygon must be convex and well under a hemisphere across; split large"
+                  " or L-shaped regions into several polygons");
         }
       }
     }
 
-    return ConvexCone(std::move(normals));
+    const double solid_angle = solidAngleFromNormals(normals);
+
+    // A polygon covering nothing would look like a working blind spot while the frustum
+    // clears straight through it. One this large is not a blind spot at all, and is the
+    // signature of edges that swept the wrong way round the sphere.
+    constexpr double kMinSolidAngle = 1e-9;  // steradians
+    constexpr double kMaxSolidAngle = M_PI;  // a quarter of the sphere; real masks are far under
+    if (solid_angle < kMinSolidAngle) {
+      throw std::runtime_error(
+              "covers a near-zero solid angle (" + std::to_string(solid_angle) +
+              " sr) and would mask nothing");
+    }
+    if (solid_angle > kMaxSolidAngle) {
+      throw std::runtime_error(
+              "covers " + std::to_string(solid_angle) +
+              " sr, far too large for a blind spot; check whether an edge's azimuth step exceeds"
+              " pi and sweeps the wrong way, and slice it into several polygons");
+    }
+
+    return ConvexCone(std::move(normals), solid_angle);
   }
 
   const std::vector<Vec3D> & normals() const { return normals_; }
 
+  /// Solid angle in steradians, the true size of the cone.
+  double getSolidAngle() const { return solid_angle_; }
+
 private:
-  explicit ConvexCone(std::vector<Vec3D> normals) : normals_(std::move(normals)) {}
+  ConvexCone(std::vector<Vec3D> normals, double solid_angle)
+  : normals_(std::move(normals)), solid_angle_(solid_angle) {}
 
   std::vector<Vec3D> normals_;
+  double solid_angle_;  // for ordering by size
 };
 
 // ---------------------------------------------------------------------------
@@ -207,17 +289,17 @@ private:
 // ---------------------------------------------------------------------------
 
 /**
- * @brief Validated 3D cone with angular area.
+ * @brief Validated 3D cone with its solid angle.
  */
 struct ValidatedPolygon
 {
-  double angular_area;  // for size based sorting
+  double solid_angle;  // steradians, for size based sorting
   ConvexCone cone;
 };
 
 /**
  * @brief Perform validity checks for each polygon
- * @return vector of valid, precomputed polygons paired with their 2D angular area
+ * @return vector of valid, precomputed polygons paired with their solid angle
  * @throws std::runtime_error on the first invalid polygon
  */
 inline std::vector<ValidatedPolygon> validatePolygons(const std::vector<AngularPolygon> & input)
@@ -243,7 +325,8 @@ inline std::vector<ValidatedPolygon> validatePolygons(const std::vector<AngularP
       if (v.azimuth < 0.0 || v.azimuth > 2.0 * M_PI) {
         throw std::runtime_error(
                 poly_name_idx + " has azimuth " + std::to_string(v.azimuth) +
-                " outside [0, 2pi]; polygons crossing the 0/2pi boundary are not supported");
+                " outside [0, 2pi]; a polygon crossing 0/2pi is supported, but write its"
+                " vertices wrapped into range (e.g. 6.2 and 0.1)");
       }
       if (v.elevation < -M_PI_2 || v.elevation > M_PI_2) {
         throw std::runtime_error(
@@ -252,17 +335,11 @@ inline std::vector<ValidatedPolygon> validatePolygons(const std::vector<AngularP
       }
     }
 
-    // A zero-area polygon would mask nothing, dont continue
-    constexpr double kMinAngularArea = 1e-9;
-    const double area = angularArea(vertices);
-    if (area < kMinAngularArea) {
-      throw std::runtime_error(
-              poly_name_idx + " has near-zero angular area (" + std::to_string(area) +
-              "), its vertices are collinear or coincident");
-    }
-
+    // Shape and size are checked on the sphere by fromAngularVertices, which rejects a cone
+    // that is degenerate, non-convex or implausibly large.
     try {
-      valid.push_back({area, ConvexCone::fromAngularVertices(vertices)});
+      ConvexCone cone = ConvexCone::fromAngularVertices(vertices);
+      valid.push_back({cone.getSolidAngle(), std::move(cone)});
     } catch (const std::exception & e) {
       throw std::runtime_error(poly_name_idx + " " + e.what());
     }
@@ -460,7 +537,7 @@ private:
     }
     std::sort(
       ordered.begin(), ordered.end(), [](const ValidatedPolygon * a, const ValidatedPolygon * b) {
-        return a->angular_area > b->angular_area;
+        return a->solid_angle > b->solid_angle;
       });
 
     // Store normals in flat vectors

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -1,0 +1,338 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD-3-Clause)
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the project nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Purpose: Convex polygon obstruction zones for frustum blind spot filtering.
+ *          Points whose coordinates in sensor-local frame fall inside
+ *          any obstruction polygon are excluded from frustum clearing.
+ *********************************************************************/
+
+#ifndef SPATIO_TEMPORAL_VOXEL_LAYER__OBSTRUCTION_POLYGONS_HPP_
+#define SPATIO_TEMPORAL_VOXEL_LAYER__OBSTRUCTION_POLYGONS_HPP_
+
+#include <vector>
+#include <cmath>
+#include <string>
+#include <sstream>
+#include <utility>
+#include <algorithm>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace geometry
+{
+
+/**
+ * @brief A generic 2D convex polygon with precomputed half-plane representation
+ *        for fast point-in-polygon queries.
+ */
+struct ConvexPolygon2D
+{
+  // Vertices as (x, y) pairs, must be convex and consistently wound
+  std::vector<std::pair<double, double>> vertices;
+
+  // Precomputed edge normals and offsets for half-plane test
+  // For edge from v[i] to v[(i+1)%n], the inward normal and offset
+  std::vector<double> nx, ny, d;
+
+  /**
+   * @brief Precompute half-plane representation for fast point-in-polygon.
+   * @return true if polygon is valid (convex, >= 3 vertices)
+   */
+  bool precompute()
+  {
+    size_t n = vertices.size();
+    if (n < 3) {
+      return false;
+    }
+
+    nx.resize(n);
+    ny.resize(n);
+    d.resize(n);
+
+    // Compute signed area to determine winding
+    double area = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+      size_t j = (i + 1) % n;
+      area += vertices[i].first * vertices[j].second;
+      area -= vertices[j].first * vertices[i].second;
+    }
+    bool ccw = area > 0.0;
+
+    for (size_t i = 0; i < n; ++i) {
+      size_t j = (i + 1) % n;
+      double ex = vertices[j].first - vertices[i].first;
+      double ey = vertices[j].second - vertices[i].second;
+
+      // Inward normal (perpendicular to edge, pointing inside)
+      if (ccw) {
+        nx[i] = -ey;  // rotate edge 90° CCW for inward normal of CCW polygon
+        ny[i] = ex;
+      } else {
+        nx[i] = ey;   // rotate edge 90° CW for inward normal of CW polygon
+        ny[i] = -ex;
+      }
+
+      // Normalize
+      double len = std::sqrt(nx[i] * nx[i] + ny[i] * ny[i]);
+      if (len < 1e-12) {
+        return false;  // degenerate edge
+      }
+      nx[i] /= len;
+      ny[i] /= len;
+
+      // Half-plane offset: the signed distance from the origin to the edge along
+      // the normal direction. By precomputing d = n·v (where v is any point on
+      // the edge), the inside test becomes n·p ≥ d — a single dot product and
+      // compare per edge — rather than n·(p - v) which requires a subtraction.
+      d[i] = nx[i] * vertices[i].first + ny[i] * vertices[i].second;
+    }
+
+    return true;
+  }
+
+  /**
+   * @brief Check if a 2D point is inside this convex polygon.
+   * Uses half-plane intersection: point must be on the inner side of all edges.
+   */
+  bool isInside(double x, double y) const
+  {
+    for (size_t i = 0; i < nx.size(); ++i) {
+      if (nx[i] * x + ny[i] * y < d[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+/**
+ * @brief Validate obstruction polygons for use in azimuth/elevation space.
+ * Checks vertex count, NaN, azimuth bounds [0, 2π], and precomputes half-planes.
+ * @return vector of valid, precomputed polygons
+ */
+inline std::vector<ConvexPolygon2D> validatePolygons(
+  const std::vector<ConvexPolygon2D> & input,
+  const rclcpp::Logger & logger)
+{
+  std::vector<ConvexPolygon2D> valid;
+  valid.reserve(input.size());
+
+  for (size_t idx = 0; idx < input.size(); ++idx) {
+    auto poly = input[idx];
+    if (poly.vertices.size() < 3) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %zu has < 3 vertices, skipping.",
+        idx);
+      continue;
+    }
+
+    // Check for NaN
+    bool has_nan = false;
+    for (const auto & v : poly.vertices) {
+      if (!std::isfinite(v.first) || !std::isfinite(v.second)) {
+        has_nan = true;
+        break;
+      }
+    }
+    if (has_nan) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %zu has NaN/inf vertices, skipping.",
+        idx);
+      continue;
+    }
+
+    // Check azimuth bounds — warn if any vertex outside [0, 2π]
+    bool out_of_range = false;
+    for (const auto & v : poly.vertices) {
+      if (v.first < 0.0 || v.first > 2.0 * M_PI) {
+        out_of_range = true;
+        break;
+      }
+    }
+    if (out_of_range) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %zu has vertices outside [0, 2pi] azimuth range, "
+        "skipping. Polygons crossing the 0/2pi boundary are not supported.",
+        idx);
+      continue;
+    }
+
+    if (!poly.precompute()) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.",
+        idx);
+      continue;
+    }
+
+    valid.push_back(std::move(poly));
+  }
+
+  return valid;
+}
+
+/**
+ * @brief Check if a point falls inside any of the obstruction polygons.
+ */
+inline bool isInsideAnyObstruction(
+  const std::vector<ConvexPolygon2D> & polygons,
+  double x, double y)
+{
+  for (const auto & poly : polygons) {
+    if (poly.isInside(x, y)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Parse a list of polygons from a footprint-style string.
+ *
+ * Format: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
+ * Each inner [...] is one polygon with flat x/y vertex pairs.
+ *
+ * @return vector of parsed (unvalidated) polygons
+ */
+inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
+  const std::string & input,
+  const rclcpp::Logger & logger)
+{
+  std::vector<ConvexPolygon2D> polygons;
+
+  // Find the outer brackets
+  size_t outer_start = input.find('[');
+  size_t outer_end = input.rfind(']');
+  if (outer_start == std::string::npos || outer_end == std::string::npos ||
+    outer_end <= outer_start)
+  {
+    RCLCPP_WARN(logger, "Obstruction polygons string has invalid format.");
+    return polygons;
+  }
+
+  // Parse inner polygon brackets
+  size_t pos = outer_start + 1;
+  int poly_idx = 0;
+  while (pos < outer_end) {
+    // Find next inner '['
+    size_t inner_start = input.find('[', pos);
+    if (inner_start == std::string::npos || inner_start >= outer_end) {
+      break;
+    }
+    size_t inner_end = input.find(']', inner_start);
+    if (inner_end == std::string::npos || inner_end > outer_end) {
+      RCLCPP_WARN(logger, "Obstruction polygons string has unmatched brackets.");
+      break;
+    }
+
+    // Extract the comma-separated numbers between inner brackets
+    std::string nums_str = input.substr(inner_start + 1, inner_end - inner_start - 1);
+    std::vector<double> values;
+    std::istringstream ss(nums_str);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+      // Trim whitespace
+      size_t start = token.find_first_not_of(" \t");
+      if (start == std::string::npos) {continue;}
+      try {
+        values.push_back(std::stod(token.substr(start)));
+      } catch (const std::exception &) {
+        RCLCPP_WARN(
+          logger, "Obstruction polygon %d: failed to parse value '%s'.",
+          poly_idx, token.c_str());
+      }
+    }
+
+    if (values.size() >= 6 && values.size() % 2 == 0) {
+      ConvexPolygon2D poly;
+      for (size_t i = 0; i < values.size(); i += 2) {
+        poly.vertices.emplace_back(values[i], values[i + 1]);
+      }
+      polygons.push_back(std::move(poly));
+    } else if (!values.empty()) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %d needs >= 6 values (3 x/y pairs), got %zu. Skipping.",
+        poly_idx, values.size());
+    }
+
+    poly_idx++;
+    pos = inner_end + 1;
+  }
+
+  return polygons;
+}
+
+/**
+ * @brief Parse obstruction polygons from a single ROS2 string parameter.
+ *
+ * Expected parameter format (footprint-style):
+ *   obstruction_polygons: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
+ *
+ * For STVL use, x=azimuth (rad), y=elevation (rad).
+ */
+template<typename NodeT>
+std::vector<ConvexPolygon2D> parseObstructionPolygonsFromParams(
+  NodeT node,
+  const std::string & param_prefix,
+  const rclcpp::Logger & logger)
+{
+  std::string param_name = param_prefix + ".obstruction_polygons";
+  std::string polygons_str;
+  if (!node->has_parameter(param_name)) {
+    node->declare_parameter(param_name, std::string(""));
+  }
+  node->get_parameter(param_name, polygons_str);
+
+  if (polygons_str.empty()) {
+    return {};
+  }
+
+  auto polygons = parsePolygonsFromString(polygons_str, logger);
+
+  if (!polygons.empty()) {
+    RCLCPP_INFO(
+      logger,
+      "Parsed %zu obstruction polygon(s) for %s",
+      polygons.size(), param_prefix.c_str());
+  }
+
+  return validatePolygons(polygons, logger);
+}
+
+}  // namespace geometry
+
+#endif  // SPATIO_TEMPORAL_VOXEL_LAYER__OBSTRUCTION_POLYGONS_HPP_

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -251,11 +251,12 @@ public:
 
     const double solid_angle = solidAngleFromNormals(normals);
 
-    // A polygon covering nothing would look like a working blind spot while the frustum
-    // clears straight through it. One this large is not a blind spot at all, and is the
-    // signature of edges that swept the wrong way round the sphere.
+    // A polygon covering nothing ( < kMinSolidAngle ) would look like a working blind spot
+    // while the frustum clears straight through it.
+    // The upper bound, kMaxSolidAngle is a plausibility judgement, not a limit of the
+    // representation. A quarter of the sphere big, typical masks are far under.
     constexpr double kMinSolidAngle = 1e-9;  // steradians
-    constexpr double kMaxSolidAngle = M_PI;  // a quarter of the sphere; real masks are far under
+    constexpr double kMaxSolidAngle = M_PI;
     if (solid_angle < kMinSolidAngle) {
       throw std::runtime_error(
               "covers a near-zero solid angle (" + std::to_string(solid_angle) +
@@ -264,7 +265,7 @@ public:
     if (solid_angle > kMaxSolidAngle) {
       throw std::runtime_error(
               "covers " + std::to_string(solid_angle) +
-              " sr, far too large for a blind spot; check whether an edge's azimuth step exceeds"
+              " sr, a very large blind spot; check whether an edge's azimuth step exceeds"
               " pi and sweeps the wrong way, and slice it into several polygons");
     }
 

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -51,22 +51,35 @@
 namespace geometry
 {
 
+struct SphericalPoint
+{
+  double azimuth;    // radians
+  double elevation;  // radians
+};
+
+struct Vec3D { double x, y, z; };
+
 /**
- * @brief A generic 2D convex polygon with precomputed half-plane representation
- *        for fast point-in-polygon queries.
+ * @brief A convex polygon defined in (azimuth, elevation) space with precomputed
+ *        3D great-circle normals for spherical point-in-polygon testing via Cartesian dot products.
+ *
+ * Vertices are stored as (azimuth, elevation) for parsing/validation/serialization.
+ * At precompute time, they are converted to 3D unit direction vectors and each edge
+ * becomes a great-circle plane through the origin. The runtime isInside() test uses
+ * only dot products on 3D points.
+ *
  */
 struct ConvexPolygon2D
 {
-  // Vertices as (x, y) pairs, must be convex and consistently wound
-  std::vector<std::pair<double, double>> vertices;
+  // Vertices as angular coordinates in radians
+  std::vector<SphericalPoint> vertices;
 
-  // Precomputed edge normals and offsets for half-plane test
-  // For edge from v[i] to v[(i+1)%n], the inward normal and offset
-  std::vector<double> nx, ny, d;
+  // Precomputed 3D great-circle plane normals (one per edge)
+  std::vector<Vec3D> normals;
 
   /**
-   * @brief Precompute half-plane representation for fast point-in-polygon.
-   * @return true if polygon is valid (convex, >= 3 vertices)
+   * @brief Convert angular (az/el) vertices to 3D directions and precompute edge normals.
+   * @return true if polygon is valid (convex, >= 3 vertices, no degenerate edges)
    */
   bool precompute()
   {
@@ -75,59 +88,68 @@ struct ConvexPolygon2D
       return false;
     }
 
-    nx.resize(n);
-    ny.resize(n);
-    d.resize(n);
-
-    // Compute signed area to determine winding
-    double area = 0.0;
+    // Convert (azimuth, elevation) vertices to 3D unit direction vectors from sensor origin
+    std::vector<Vec3D> dirs(n);
     for (size_t i = 0; i < n; ++i) {
-      size_t j = (i + 1) % n;
-      area += vertices[i].first * vertices[j].second;
-      area -= vertices[j].first * vertices[i].second;
+      double az = vertices[i].azimuth;
+      double el = vertices[i].elevation;
+      // Convert spherical to Cartesian coordinates
+      double cos_el = std::cos(el);
+      dirs[i] = {cos_el * std::cos(az), cos_el * std::sin(az), std::sin(el)};
     }
-    bool ccw = area > 0.0;
 
+    // Compute edge normals as cross products of adjacent direction vectors
+    normals.resize(n);
     for (size_t i = 0; i < n; ++i) {
-      size_t j = (i + 1) % n;
-      double ex = vertices[j].first - vertices[i].first;
-      double ey = vertices[j].second - vertices[i].second;
+      size_t j = (i + 1) % n;  // index of next vertex
+      normals[i].x = dirs[i].y * dirs[j].z - dirs[i].z * dirs[j].y;
+      normals[i].y = dirs[i].z * dirs[j].x - dirs[i].x * dirs[j].z;
+      normals[i].z = dirs[i].x * dirs[j].y - dirs[i].y * dirs[j].x;
 
-      // Inward normal (perpendicular to edge, pointing inside)
-      if (ccw) {
-        nx[i] = -ey;  // rotate edge 90° CCW for inward normal of CCW polygon
-        ny[i] = ex;
-      } else {
-        nx[i] = ey;   // rotate edge 90° CW for inward normal of CW polygon
-        ny[i] = -ex;
+      // Check for degenerate edge (coincident vertices)
+      double len_sq = normals[i].x * normals[i].x +
+                      normals[i].y * normals[i].y +
+                      normals[i].z * normals[i].z;
+
+      constexpr double kMinEdgeNormSquared = 1e-12;  // reject edges < ~0.001° apart
+      if (len_sq < kMinEdgeNormSquared) {
+        return false;
       }
+    }
 
-      // Normalize
-      double len = std::sqrt(nx[i] * nx[i] + ny[i] * ny[i]);
-      if (len < 1e-12) {
-        return false;  // degenerate edge
+    // Determine orientation: centroid direction should be on inside of all half-planes
+    Vec3D centroid{0.0, 0.0, 0.0};
+    for (const auto & d : dirs) {
+      centroid.x += d.x;
+      centroid.y += d.y;
+      centroid.z += d.z;
+    }
+
+    // flip normals if pointing outward (dot product with centroid < 0)
+    double test_dot = normals[0].x * centroid.x +
+                      normals[0].y * centroid.y +
+                      normals[0].z * centroid.z;
+    if (test_dot < 0.0) {
+      for (auto & norm : normals) {
+        norm.x = -norm.x;
+        norm.y = -norm.y;
+        norm.z = -norm.z;
       }
-      nx[i] /= len;
-      ny[i] /= len;
-
-      // Half-plane offset: the signed distance from the origin to the edge along
-      // the normal direction. By precomputing d = n·v (where v is any point on
-      // the edge), the inside test becomes n·p ≥ d — a single dot product and
-      // compare per edge — rather than n·(p - v) which requires a subtraction.
-      d[i] = nx[i] * vertices[i].first + ny[i] * vertices[i].second;
     }
 
     return true;
   }
 
   /**
-   * @brief Check if a 2D point is inside this convex polygon.
-   * Uses half-plane intersection: point must be on the inner side of all edges.
+   * @brief Check if a 3D direction is inside this polygon.
+   * Takes the raw cartesian direction from sensor origin, no normalization needed
+   * since dot-product sign is scale-invariant.
    */
-  bool isInside(double x, double y) const
+  bool isInside(double x, double y, double z) const
   {
-    for (size_t i = 0; i < nx.size(); ++i) {
-      if (nx[i] * x + ny[i] * y < d[i]) {
+    for (const auto & n : normals) {
+      // if any of the dot-product tests fail, early return false
+      if (n.x * x + n.y * y + n.z * z < 0.0) {
         return false;
       }
     }
@@ -160,7 +182,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
     // Check for NaN
     bool has_nan = false;
     for (const auto & v : poly.vertices) {
-      if (!std::isfinite(v.first) || !std::isfinite(v.second)) {
+      if (!std::isfinite(v.azimuth) || !std::isfinite(v.elevation)) {
         has_nan = true;
         break;
       }
@@ -176,7 +198,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
     // Check azimuth bounds — warn if any vertex outside [0, 2π]
     bool out_of_range = false;
     for (const auto & v : poly.vertices) {
-      if (v.first < 0.0 || v.first > 2.0 * M_PI) {
+      if (v.azimuth < 0.0 || v.azimuth > 2.0 * M_PI) {
         out_of_range = true;
         break;
       }
@@ -205,14 +227,15 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
 }
 
 /**
- * @brief Check if a point falls inside any of the obstruction polygons.
+ * @brief Check if a 3D direction falls inside any of the obstruction polygons.
+ * Takes raw cartesian direction (x, y, z) from sensor frame.
  */
 inline bool isInsideAnyObstruction(
   const std::vector<ConvexPolygon2D> & polygons,
-  double x, double y)
+  double x, double y, double z)
 {
   for (const auto & poly : polygons) {
-    if (poly.isInside(x, y)) {
+    if (poly.isInside(x, y, z)) {
       return true;
     }
   }
@@ -279,7 +302,7 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
     if (values.size() >= 6 && values.size() % 2 == 0) {
       ConvexPolygon2D poly;
       for (size_t i = 0; i < values.size(); i += 2) {
-        poly.vertices.emplace_back(values[i], values[i + 1]);
+        poly.vertices.push_back({values[i], values[i + 1]});
       }
       polygons.push_back(std::move(poly));
     } else if (!values.empty()) {

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -41,6 +41,7 @@
 
 #include <vector>
 #include <cmath>
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <utility>
@@ -237,6 +238,113 @@ inline bool isInsideAnyObstruction(
   for (const auto & poly : polygons) {
     if (poly.isInside(x, y, z)) {
       return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Flat, contiguous Structure-of-Arrays (SoA) storage of all obstruction
+ *        polygon edge normals, for fast point in polygon testing.
+ */
+struct ObstructionField
+{
+  // All edge normals for all polygons, contiguous, SoA
+  std::vector<float> nx;
+  std::vector<float> ny;
+  std::vector<float> nz;
+
+  // Span to indicate where each polygon's normals are in the vectors
+  struct Span
+  {
+    uint32_t start;
+    uint32_t count;
+  };
+  std::vector<Span> polygons;
+
+  bool empty() const {return polygons.empty();}
+};
+
+/**
+ * @brief Angular area size of a polygon using shoelace formula
+ */
+inline double polygonAngularArea(const ConvexPolygon2D & p)
+{
+  const size_t n = p.vertices.size();
+  double area2 = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    const auto & v0 = p.vertices[i];
+    const auto & v1 = p.vertices[(i + 1) % n];
+    area2 += v0.azimuth * v1.elevation - v1.azimuth * v0.elevation;
+  }
+  return std::fabs(area2) * 0.5;
+}
+
+/**
+ * @brief Convert validated/precomputed polygons to flat SoA and sort by angular area
+ */
+inline ObstructionField flattenAndSortPolygons(
+  const std::vector<ConvexPolygon2D> & polygons)
+{
+  ObstructionField field;
+
+  // Index polygons, largest-area first
+  std::vector<const ConvexPolygon2D *> poly2d_ordered;
+  poly2d_ordered.reserve(polygons.size());
+  for (const auto & poly : polygons) {
+    poly2d_ordered.push_back(&poly);
+  }
+  std::sort(
+    poly2d_ordered.begin(), poly2d_ordered.end(),
+    [](const ConvexPolygon2D * a, const ConvexPolygon2D * b) {
+      return polygonAngularArea(*a) > polygonAngularArea(*b);
+    });
+
+  // Store normals in flat vectors
+  size_t total_edges = 0;
+  for (const auto * poly : poly2d_ordered) {
+    total_edges += poly->normals.size();
+  }
+  field.nx.reserve(total_edges);
+  field.ny.reserve(total_edges);
+  field.nz.reserve(total_edges);
+  field.polygons.reserve(poly2d_ordered.size());
+
+  for (const auto * poly : poly2d_ordered) {
+    ObstructionField::Span span;
+    span.start = static_cast<uint32_t>(field.nx.size());
+    span.count = static_cast<uint32_t>(poly->normals.size());
+    for (const auto & normal : poly->normals) {
+      field.nx.push_back(static_cast<float>(normal.x));
+      field.ny.push_back(static_cast<float>(normal.y));
+      field.nz.push_back(static_cast<float>(normal.z));
+    }
+    field.polygons.push_back(span);
+  }
+
+  return field;
+}
+
+/**
+ * @brief Check if a 3D direction falls inside any obstruction polygon
+ */
+inline bool isInsideAnyObstruction(
+  const ObstructionField & field,
+  float x, float y, float z)
+{
+  const float* nx = field.nx.data();
+  const float* ny = field.ny.data();
+  const float* nz = field.nz.data();
+
+  for (const auto& span : field.polygons) {
+    const uint32_t end = span.start + span.count;
+    int any_negative = 0;
+    for (uint32_t i = span.start; i < end; ++i) {
+      const float dot = nx[i] * x + ny[i] * y + nz[i] * z;
+      any_negative = any_negative | (dot < 0.0f);
+    }
+    if (!any_negative) {
+      return true;  // inside this polygon -> inside some obstruction
     }
   }
   return false;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -138,6 +138,20 @@ struct ConvexPolygon2D
       }
     }
 
+    // Verify spherical convexity. isInside()'s sequential cross product needs spherical convexity to be valid.
+    // Check that all vertices are on the same side of each edge's great-circle plane.
+    constexpr double kConvexEps = 1e-9;  // tolerance for vertices lying on an edge's line
+    for (size_t i = 0; i < n; ++i) {
+      for (size_t k = 0; k < n; ++k) {
+        double side = normals[i].x * dirs[k].x +
+                      normals[i].y * dirs[k].y +
+                      normals[i].z * dirs[k].z;
+        if (side < -kConvexEps) {
+          return false;  // non-convex polygon: reject rather than mis-test
+        }
+      }
+    }
+
     return true;
   }
 
@@ -214,7 +228,7 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
     }
 
     if (!poly.precompute()) {
-      RCLCPP_WARN(
+      RCLCPP_ERROR(
         logger,
         "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.",
         idx);

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  * Purpose: Convex polygon obstruction zones for frustum blind spot filtering.
- *          Points whose coordinates in sensor-local frame fall inside
+ *          Points (voxels) whose coordinates in sensor-local frame fall inside
  *          any obstruction polygon are excluded from frustum clearing.
  *********************************************************************/
 
@@ -42,6 +42,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -52,11 +54,41 @@
 namespace geometry
 {
 
+// Polygons are supplied in the 2D angular domain, sorted by size, converted to
+// the 3D directional domain, and used in the ObstructionFilter class to do
+// fast point-in-polygon checks
+// Polygon data pipeline: parse from parameters -> vertices to 3d directions ->
+//                        3d directions to edge plane normals -> 3D normals to flat SoA.
+
+// ---------------------------------------------------------------------------
+// 2D / angular domain
+// ---------------------------------------------------------------------------
+
 struct SphericalPoint
 {
   double azimuth;    // radians
   double elevation;  // radians
 };
+using AngularPolygon = std::vector<SphericalPoint>;
+
+/**
+ * @brief Angular area of a 2D (azimuth, elevation) polygon via the shoelace formula.
+ */
+inline double angularArea(const AngularPolygon & vertices)
+{
+  const size_t n = vertices.size();
+  double area2 = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    const auto & v0 = vertices[i];
+    const auto & v1 = vertices[(i + 1) % n];
+    area2 += v0.azimuth * v1.elevation - v1.azimuth * v0.elevation;
+  }
+  return std::fabs(area2) * 0.5;
+}
+
+// ---------------------------------------------------------------------------
+// 3D / directional domain
+// ---------------------------------------------------------------------------
 
 struct Vec3D
 {
@@ -64,46 +96,40 @@ struct Vec3D
 };
 
 /**
- * @brief A convex polygon defined in (azimuth, elevation) space with precomputed
- *        3D great-circle normals for spherical point-in-polygon testing via Cartesian dot products.
- *
- * Vertices are stored as (azimuth, elevation) for parsing/validation/serialization.
- * At precompute time, they are converted to 3D unit direction vectors and each edge
- * becomes a great-circle plane through the origin. The runtime isInside() test uses
- * only dot products on 3D points.
- *
+ * @brief The 3D/directional counterpart of the 2D angular polygon: a convex
+ *        polyhedral cone through the origin, defined as the intersection of
+ *        great-circle half-planes (one per polygon edge). Used for
+ *        point-in-polygon tests on directions instead of points.
  */
-struct ConvexPolygon2D
+class ConvexCone
 {
-  // Vertices as angular coordinates in radians
-  std::vector<SphericalPoint> vertices;
-
-  // Precomputed 3D great-circle plane normals (one per edge)
-  std::vector<Vec3D> normals;
-
+public:
   /**
-   * @brief Convert angular (az/el) vertices to 3D directions and precompute edge normals.
-   * @return true if polygon is valid (convex, >= 3 vertices, no degenerate edges)
+   * @brief Project angular (az/el) vertices onto the unit sphere and compute the
+   *        great-circle half-plane normal for each edge.
+   * @return the resulting cone, or std::nullopt if the vertices are too few, produce a
+   *         degenerate edge, or are not spherically convex.
    */
-  bool precompute()
+  static std::optional<ConvexCone> fromAngularVertices(const AngularPolygon & vertices)
   {
-    size_t n = vertices.size();
+    const size_t n = vertices.size();
     if (n < 3) {
-      return false;
+      return std::nullopt;
     }
 
-    // Convert (azimuth, elevation) vertices to 3D unit direction vectors from sensor origin
+    // 2D -> 3D: convert (azimuth, elevation) vertices to 3D unit direction vectors
+    // from the sensor origin.
     std::vector<Vec3D> dirs(n);
     for (size_t i = 0; i < n; ++i) {
-      double az = vertices[i].azimuth;
-      double el = vertices[i].elevation;
-      // Convert spherical to Cartesian coordinates
-      double cos_el = std::cos(el);
+      const double az = vertices[i].azimuth;
+      const double el = vertices[i].elevation;
+      const double cos_el = std::cos(el);
       dirs[i] = {cos_el * std::cos(az), cos_el * std::sin(az), std::sin(el)};
     }
 
     // Compute edge normals as cross products of adjacent direction vectors
-    normals.resize(n);
+    // The cross product will give the normal to the plane spanned by the two direction vectors.
+    std::vector<Vec3D> normals(n);
     for (size_t i = 0; i < n; ++i) {
       size_t j = (i + 1) % n;  // index of next vertex
       normals[i].x = dirs[i].y * dirs[j].z - dirs[i].z * dirs[j].y;
@@ -111,12 +137,12 @@ struct ConvexPolygon2D
       normals[i].z = dirs[i].x * dirs[j].y - dirs[i].y * dirs[j].x;
 
       // Check for degenerate edge (coincident vertices)
-      double len_sq =
+      const double len_sq =
         normals[i].x * normals[i].x + normals[i].y * normals[i].y + normals[i].z * normals[i].z;
 
       constexpr double kMinEdgeNormSquared = 1e-12;  // reject edges < ~0.001° apart
       if (len_sq < kMinEdgeNormSquared) {
-        return false;
+        return std::nullopt;
       }
     }
 
@@ -129,7 +155,7 @@ struct ConvexPolygon2D
     }
 
     // flip normals if pointing outward (dot product with centroid < 0)
-    double test_dot =
+    const double test_dot =
       normals[0].x * centroid.x + normals[0].y * centroid.y + normals[0].z * centroid.z;
     if (test_dot < 0.0) {
       for (auto & norm : normals) {
@@ -139,73 +165,75 @@ struct ConvexPolygon2D
       }
     }
 
-    // Verify spherical convexity. isInside()'s sequential cross product needs spherical convexity to be valid.
-    // Check that all vertices are on the same side of each edge's great-circle plane.
+    // Verify spherical convexity. For each edge all vertices must lay on same side
     constexpr double kConvexEps = 1e-9;  // tolerance for vertices lying on an edge's line
     for (size_t i = 0; i < n; ++i) {
       for (size_t k = 0; k < n; ++k) {
-        double side =
+        const double side =
           normals[i].x * dirs[k].x + normals[i].y * dirs[k].y + normals[i].z * dirs[k].z;
         if (side < -kConvexEps) {
-          return false;  // non-convex polygon: reject rather than mis-test
+          return std::nullopt;  // non-convex polygon: reject
         }
       }
     }
 
-    return true;
+    return ConvexCone(std::move(normals));
   }
 
-  /**
-   * @brief Check if a 3D direction is inside this polygon.
-   * Takes the raw cartesian direction from sensor origin, no normalization needed
-   * since dot-product sign is scale-invariant.
-   */
-  bool isInside(double x, double y, double z) const
-  {
-    for (const auto & n : normals) {
-      // if any of the dot-product tests fail, early return false
-      if (n.x * x + n.y * y + n.z * z < 0.0) {
-        return false;
-      }
-    }
-    return true;
-  }
+  const std::vector<Vec3D> & normals() const { return normals_; }
+
+private:
+  explicit ConvexCone(std::vector<Vec3D> normals) : normals_(std::move(normals)) {}
+
+  std::vector<Vec3D> normals_;
+};
+
+// ---------------------------------------------------------------------------
+// Parsing and validation
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Validated 3D cone with angular area.
+ */
+struct ValidatedPolygon
+{
+  double angular_area;  // for size based sorting
+  ConvexCone cone;
 };
 
 /**
- * @brief Validate obstruction polygons for use in azimuth/elevation space.
- * Checks vertex count, NaN, azimuth bounds [0, 2π], and precomputes half-planes.
- * @return vector of valid, precomputed polygons
+ * @brief Perform validity checks for each polygon
+ * @return vector of valid, precomputed polygons paired with their 2D angular area
  */
-inline std::vector<ConvexPolygon2D> validatePolygons(
-  const std::vector<ConvexPolygon2D> & input, const rclcpp::Logger & logger)
+inline std::vector<ValidatedPolygon> validatePolygons(
+  const std::vector<AngularPolygon> & input, const rclcpp::Logger & logger)
 {
-  std::vector<ConvexPolygon2D> valid;
+  std::vector<ValidatedPolygon> valid;
   valid.reserve(input.size());
 
   for (size_t idx = 0; idx < input.size(); ++idx) {
-    auto poly = input[idx];
-    if (poly.vertices.size() < 3) {
+    const auto & vertices = input[idx];
+    if (vertices.size() < 3) {
       RCLCPP_WARN(logger, "Obstruction polygon %zu has < 3 vertices, skipping.", idx);
       continue;
     }
 
-    // Check for NaN
-    bool has_nan = false;
-    for (const auto & v : poly.vertices) {
+    // Check for NaN/inf
+    bool is_finite = false;
+    for (const auto & v : vertices) {
       if (!std::isfinite(v.azimuth) || !std::isfinite(v.elevation)) {
-        has_nan = true;
+        is_finite = true;
         break;
       }
     }
-    if (has_nan) {
+    if (is_finite) {
       RCLCPP_WARN(logger, "Obstruction polygon %zu has NaN/inf vertices, skipping.", idx);
       continue;
     }
 
-    // Check azimuth bounds — warn if any vertex outside [0, 2π]
+    // Verify azimuth within bounds [0-2pi]
     bool out_of_range = false;
-    for (const auto & v : poly.vertices) {
+    for (const auto & v : vertices) {
       if (v.azimuth < 0.0 || v.azimuth > 2.0 * M_PI) {
         out_of_range = true;
         break;
@@ -220,136 +248,18 @@ inline std::vector<ConvexPolygon2D> validatePolygons(
       continue;
     }
 
-    if (!poly.precompute()) {
+    std::optional<ConvexCone> cone = ConvexCone::fromAngularVertices(vertices);
+    if (!cone) {
       RCLCPP_ERROR(
         logger,
         "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.", idx);
       continue;
     }
 
-    valid.push_back(std::move(poly));
+    valid.push_back({angularArea(vertices), std::move(*cone)});
   }
 
   return valid;
-}
-
-/**
- * @brief Check if a 3D direction falls inside any of the obstruction polygons.
- * Takes raw cartesian direction (x, y, z) from sensor frame.
- */
-inline bool isInsideAnyObstruction(
-  const std::vector<ConvexPolygon2D> & polygons, double x, double y, double z)
-{
-  for (const auto & poly : polygons) {
-    if (poly.isInside(x, y, z)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * @brief Flat, contiguous Structure-of-Arrays (SoA) storage of all obstruction
- *        polygon edge normals, for fast point in polygon testing.
- */
-struct ObstructionField
-{
-  // All edge normals for all polygons, contiguous, SoA
-  std::vector<float> nx;
-  std::vector<float> ny;
-  std::vector<float> nz;
-
-  // Span to indicate where each polygon's normals are in the vectors
-  struct Span
-  {
-    uint32_t start;
-    uint32_t count;
-  };
-  std::vector<Span> polygons;
-
-  bool empty() const { return polygons.empty(); }
-};
-
-/**
- * @brief Angular area size of a polygon using shoelace formula
- */
-inline double polygonAngularArea(const ConvexPolygon2D & p)
-{
-  const size_t n = p.vertices.size();
-  double area2 = 0.0;
-  for (size_t i = 0; i < n; ++i) {
-    const auto & v0 = p.vertices[i];
-    const auto & v1 = p.vertices[(i + 1) % n];
-    area2 += v0.azimuth * v1.elevation - v1.azimuth * v0.elevation;
-  }
-  return std::fabs(area2) * 0.5;
-}
-
-/**
- * @brief Convert validated/precomputed polygons to flat SoA and sort by angular area
- */
-inline ObstructionField flattenAndSortPolygons(const std::vector<ConvexPolygon2D> & polygons)
-{
-  ObstructionField field;
-
-  // Index polygons, largest-area first
-  std::vector<const ConvexPolygon2D *> poly2d_ordered;
-  poly2d_ordered.reserve(polygons.size());
-  for (const auto & poly : polygons) {
-    poly2d_ordered.push_back(&poly);
-  }
-  std::sort(
-    poly2d_ordered.begin(), poly2d_ordered.end(),
-    [](const ConvexPolygon2D * a, const ConvexPolygon2D * b) {
-      return polygonAngularArea(*a) > polygonAngularArea(*b);
-    });
-
-  // Store normals in flat vectors
-  size_t total_edges = 0;
-  for (const auto * poly : poly2d_ordered) {
-    total_edges += poly->normals.size();
-  }
-  field.nx.reserve(total_edges);
-  field.ny.reserve(total_edges);
-  field.nz.reserve(total_edges);
-  field.polygons.reserve(poly2d_ordered.size());
-
-  for (const auto * poly : poly2d_ordered) {
-    ObstructionField::Span span;
-    span.start = static_cast<uint32_t>(field.nx.size());
-    span.count = static_cast<uint32_t>(poly->normals.size());
-    for (const auto & normal : poly->normals) {
-      field.nx.push_back(static_cast<float>(normal.x));
-      field.ny.push_back(static_cast<float>(normal.y));
-      field.nz.push_back(static_cast<float>(normal.z));
-    }
-    field.polygons.push_back(span);
-  }
-
-  return field;
-}
-
-/**
- * @brief Check if a 3D direction falls inside any obstruction polygon
- */
-inline bool isInsideAnyObstruction(const ObstructionField & field, float x, float y, float z)
-{
-  const float * nx = field.nx.data();
-  const float * ny = field.ny.data();
-  const float * nz = field.nz.data();
-
-  for (const auto & span : field.polygons) {
-    const uint32_t end = span.start + span.count;
-    int any_negative = 0;
-    for (uint32_t i = span.start; i < end; ++i) {
-      const float dot = nx[i] * x + ny[i] * y + nz[i] * z;
-      any_negative = any_negative | (dot < 0.0f);
-    }
-    if (!any_negative) {
-      return true;  // inside this polygon -> inside some obstruction
-    }
-  }
-  return false;
 }
 
 /**
@@ -358,12 +268,12 @@ inline bool isInsideAnyObstruction(const ObstructionField & field, float x, floa
  * Format: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
  * Each inner [...] is one polygon with flat x/y vertex pairs.
  *
- * @return vector of parsed (unvalidated) polygons
+ * @return vector of parsed angular-domain polygons
  */
-inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
+inline std::vector<AngularPolygon> parsePolygonsFromString(
   const std::string & input, const rclcpp::Logger & logger)
 {
-  std::vector<ConvexPolygon2D> polygons;
+  std::vector<AngularPolygon> polygons;
 
   // Find the outer brackets
   size_t outer_start = input.find('[');
@@ -410,11 +320,12 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
     }
 
     if (values.size() >= 6 && values.size() % 2 == 0) {
-      ConvexPolygon2D poly;
+      AngularPolygon vertices;
+      vertices.reserve(values.size() / 2);
       for (size_t i = 0; i < values.size(); i += 2) {
-        poly.vertices.push_back({values[i], values[i + 1]});
+        vertices.push_back({values[i], values[i + 1]});
       }
-      polygons.push_back(std::move(poly));
+      polygons.push_back(std::move(vertices));
     } else if (!values.empty()) {
       RCLCPP_WARN(
         logger, "Obstruction polygon %d needs >= 6 values (3 x/y pairs), got %zu. Skipping.",
@@ -429,37 +340,138 @@ inline std::vector<ConvexPolygon2D> parsePolygonsFromString(
 }
 
 /**
- * @brief Parse obstruction polygons from a single ROS2 string parameter.
- *
- * Expected parameter format (footprint-style):
- *   obstruction_polygons: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
- *
- * For STVL use, x=azimuth (rad), y=elevation (rad).
+ * @brief Flat, contiguous Structure-of-Arrays (SoA) store of obstruction polygon
+ *        3D edge normals, queried via isObstructed() on the frustum point-clearing
+ *        hot path.
  */
-template <typename NodeT>
-std::vector<ConvexPolygon2D> parseObstructionPolygonsFromParams(
-  NodeT node, const std::string & param_prefix, const rclcpp::Logger & logger)
+class ObstructionFilter
 {
-  std::string param_name = param_prefix + ".obstruction_polygons";
-  std::string polygons_str;
-  if (!node->has_parameter(param_name)) {
-    node->declare_parameter(param_name, std::string(""));
+public:
+  ObstructionFilter() = default;
+
+  bool empty() const { return polygons_.empty(); }
+
+  /**
+   * @brief Check if a 3D direction falls inside any obstruction polygon
+   */
+  inline bool isObstructed(float x, float y, float z) const
+  {
+    if (polygons_.empty()) return false;
+
+    const float * nx = nx_.data();
+    const float * ny = ny_.data();
+    const float * nz = nz_.data();
+
+    // to be obstructed (in polygon), each dot product of direction with polygon normals should
+    // be positive. If there is any negative dot product, this direction is not obstructed
+    for (const auto & span : polygons_) {
+      const uint32_t end = span.start + span.count;
+      int any_negative = 0;
+      for (uint32_t i = span.start; i < end; ++i) {
+        const float dot = nx[i] * x + ny[i] * y + nz[i] * z;
+        any_negative = any_negative | (dot < 0.0f);
+      }
+      if (!any_negative) {  // if all positive, direction is obstructed by this polygon
+        return true;
+      }
+    }
+    return false;
   }
-  node->get_parameter(param_name, polygons_str);
 
-  if (polygons_str.empty()) {
-    return {};
+  /**
+   * @brief Parse obstruction polygons from a single ROS2 string parameter.
+   *
+   * Expected parameter format (footprint-style):
+   *   obstruction_polygons: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
+   *   x=azimuth (rad), y=elevation (rad).
+   */
+  template <typename NodeT>
+  static std::shared_ptr<ObstructionFilter> fromParams(
+    NodeT node, const std::string & param_prefix, const rclcpp::Logger & logger)
+  {
+    std::string param_name = param_prefix + ".obstruction_polygons";
+    std::string polygons_str;
+    if (!node->has_parameter(param_name)) {
+      node->declare_parameter(param_name, std::string(""));
+    }
+    node->get_parameter(param_name, polygons_str);
+
+    if (polygons_str.empty()) {
+      return nullptr;
+    }
+
+    auto raw_polygons = parsePolygonsFromString(polygons_str, logger);
+
+    if (!raw_polygons.empty()) {
+      RCLCPP_INFO(
+        logger, "Parsed %zu obstruction polygon(s) for %s", raw_polygons.size(),
+        param_prefix.c_str());
+    }
+
+    auto valid_polygons = validatePolygons(raw_polygons, logger);
+    if (valid_polygons.empty()) {
+      return nullptr;
+    }
+
+    auto filter = std::make_shared<ObstructionFilter>();
+    filter->flattenAndSortPolygons(valid_polygons);
+    return filter;
   }
 
-  auto polygons = parsePolygonsFromString(polygons_str, logger);
+private:
+  // Span to indicate where each polygon's normals are in the vectors
+  struct Span
+  {
+    uint32_t start;
+    uint32_t count;
+  };
 
-  if (!polygons.empty()) {
-    RCLCPP_INFO(
-      logger, "Parsed %zu obstruction polygon(s) for %s", polygons.size(), param_prefix.c_str());
+  // Flat, contiguous Structure-of-Arrays (SoA) storage of all obstruction
+  // polygon edge normals, for fast point in polygon testing.
+  std::vector<float> nx_;
+  std::vector<float> ny_;
+  std::vector<float> nz_;
+  std::vector<Span> polygons_;
+
+  /**
+   * @brief Convert validated cones to flat SoA, largest angular area first.
+   */
+  void flattenAndSortPolygons(const std::vector<ValidatedPolygon> & polygons)
+  {
+    // Index polygons, largest-area first
+    std::vector<const ValidatedPolygon *> ordered;
+    ordered.reserve(polygons.size());
+    for (const auto & poly : polygons) {
+      ordered.push_back(&poly);
+    }
+    std::sort(
+      ordered.begin(), ordered.end(), [](const ValidatedPolygon * a, const ValidatedPolygon * b) {
+        return a->angular_area > b->angular_area;
+      });
+
+    // Store normals in flat vectors
+    size_t total_edges = 0;
+    for (const auto * poly : ordered) {
+      total_edges += poly->cone.normals().size();
+    }
+    nx_.reserve(total_edges);
+    ny_.reserve(total_edges);
+    nz_.reserve(total_edges);
+    polygons_.reserve(ordered.size());
+
+    for (const auto * poly : ordered) {
+      Span span;
+      span.start = static_cast<uint32_t>(nx_.size());
+      span.count = static_cast<uint32_t>(poly->cone.normals().size());
+      for (const auto & normal : poly->cone.normals()) {
+        nx_.push_back(static_cast<float>(normal.x));
+        ny_.push_back(static_cast<float>(normal.y));
+        nz_.push_back(static_cast<float>(normal.z));
+      }
+      polygons_.push_back(span);
+    }
   }
-
-  return validatePolygons(polygons, logger);
-}
+};
 
 }  // namespace geometry
 

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -45,6 +45,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -107,14 +108,15 @@ public:
   /**
    * @brief Project angular (az/el) vertices onto the unit sphere and compute the
    *        great-circle half-plane normal for each edge.
-   * @return the resulting cone, or std::nullopt if the vertices are too few, produce a
-   *         degenerate edge, or are not spherically convex.
+   * @return the resulting cone
+   * @throws std::runtime_error if the vertices are too few, produce a degenerate edge, or
+   *         are not spherically convex.
    */
-  static std::optional<ConvexCone> fromAngularVertices(const AngularPolygon & vertices)
+  static ConvexCone fromAngularVertices(const AngularPolygon & vertices)
   {
     const size_t n = vertices.size();
     if (n < 3) {
-      return std::nullopt;
+      throw std::runtime_error("polygon has " + std::to_string(n) + " vertices, needs at least 3");
     }
 
     // 2D -> 3D: convert (azimuth, elevation) vertices to 3D unit direction vectors
@@ -140,9 +142,11 @@ public:
       const double len_sq =
         normals[i].x * normals[i].x + normals[i].y * normals[i].y + normals[i].z * normals[i].z;
 
-      constexpr double kMinEdgeNormSquared = 1e-12;  // reject edges < ~0.001° apart
+      constexpr double kMinEdgeNormSquared = 1e-12;
       if (len_sq < kMinEdgeNormSquared) {
-        return std::nullopt;
+        throw std::runtime_error(
+                "has a degenerate edge between vertices " + std::to_string(i) + " and " +
+                std::to_string(j) + ": the two directions are coincident");
       }
     }
 
@@ -154,7 +158,7 @@ public:
       centroid.z += d.z;
     }
 
-    // flip normals if pointing outward (dot product with centroid < 0)
+    // flip normals if pointing outward (dot product with centroid < 0) winding detection
     const double test_dot =
       normals[0].x * centroid.x + normals[0].y * centroid.y + normals[0].z * centroid.z;
     if (test_dot < 0.0) {
@@ -172,7 +176,9 @@ public:
         const double side =
           normals[i].x * dirs[k].x + normals[i].y * dirs[k].y + normals[i].z * dirs[k].z;
         if (side < -kConvexEps) {
-          return std::nullopt;  // non-convex polygon: reject
+          throw std::runtime_error(
+                  "is not spherically convex: vertex " + std::to_string(k) +
+                  " lies outside the edge starting at vertex " + std::to_string(i));
         }
       }
     }
@@ -204,71 +210,54 @@ struct ValidatedPolygon
 /**
  * @brief Perform validity checks for each polygon
  * @return vector of valid, precomputed polygons paired with their 2D angular area
+ * @throws std::runtime_error on the first invalid polygon
  */
-inline std::vector<ValidatedPolygon> validatePolygons(
-  const std::vector<AngularPolygon> & input, const rclcpp::Logger & logger)
+inline std::vector<ValidatedPolygon> validatePolygons(const std::vector<AngularPolygon> & input)
 {
   std::vector<ValidatedPolygon> valid;
   valid.reserve(input.size());
 
   for (size_t idx = 0; idx < input.size(); ++idx) {
     const auto & vertices = input[idx];
+    const std::string poly_name_idx = "obstruction polygon " + std::to_string(idx);
+
     if (vertices.size() < 3) {
-      RCLCPP_WARN(logger, "Obstruction polygon %zu has < 3 vertices, skipping.", idx);
-      continue;
+      throw std::runtime_error(
+              poly_name_idx + " has " + std::to_string(vertices.size()) +
+              " vertices, needs at least 3");
     }
 
-    // Check for NaN/inf
-    bool is_finite = false;
+    // Check finiteness and value range
     for (const auto & v : vertices) {
       if (!std::isfinite(v.azimuth) || !std::isfinite(v.elevation)) {
-        is_finite = true;
-        break;
+        throw std::runtime_error(poly_name_idx + " has a NaN or inf vertex");
       }
-    }
-    if (is_finite) {
-      RCLCPP_WARN(logger, "Obstruction polygon %zu has NaN/inf vertices, skipping.", idx);
-      continue;
-    }
-
-    // Verify azimuth within bounds [0-2pi] and elevation within bounds [-pi/2, pi/2].
-    bool azimuth_out_of_range = false;
-    bool elevation_out_of_range = false;
-    for (const auto & v : vertices) {
       if (v.azimuth < 0.0 || v.azimuth > 2.0 * M_PI) {
-        azimuth_out_of_range = true;
-        break;
+        throw std::runtime_error(
+                poly_name_idx + " has azimuth " + std::to_string(v.azimuth) +
+                " outside [0, 2pi]; polygons crossing the 0/2pi boundary are not supported");
       }
       if (v.elevation < -M_PI_2 || v.elevation > M_PI_2) {
-        elevation_out_of_range = true;
-        break;
+        throw std::runtime_error(
+                poly_name_idx + " has elevation " + std::to_string(v.elevation) +
+                " outside [-pi/2, pi/2]");
       }
     }
-    if (azimuth_out_of_range) {
-      RCLCPP_WARN(
-        logger,
-        "Obstruction polygon %zu has vertices outside [0, 2pi] azimuth range, "
-        "skipping. Polygons crossing the 0/2pi boundary are not supported.",
-        idx);
-      continue;
-    }
-    if (elevation_out_of_range) {
-      RCLCPP_WARN(
-        logger,
-        "Obstruction polygon %zu has vertices outside [-pi/2, pi/2] elevation range, skipping.",
-        idx);
-      continue;
+
+    // A zero-area polygon would mask nothing, dont continue
+    constexpr double kMinAngularArea = 1e-9;
+    const double area = angularArea(vertices);
+    if (area < kMinAngularArea) {
+      throw std::runtime_error(
+              poly_name_idx + " has near-zero angular area (" + std::to_string(area) +
+              "), its vertices are collinear or coincident");
     }
 
-    std::optional<ConvexCone> cone = ConvexCone::fromAngularVertices(vertices);
-    if (!cone) {
-      RCLCPP_ERROR(
-        logger,
-        "Obstruction polygon %zu failed precomputation (non-convex or degenerate), skipping.", idx);
-      continue;
+    try {
+      valid.push_back({area, ConvexCone::fromAngularVertices(vertices)});
+    } catch (const std::exception & e) {
+      throw std::runtime_error(poly_name_idx + " " + e.what());
     }
-
-    valid.push_back({angularArea(vertices), std::move(*cone)});
   }
 
   return valid;
@@ -280,10 +269,12 @@ inline std::vector<ValidatedPolygon> validatePolygons(
  * Format: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
  * Each inner [...] is one polygon with flat x/y vertex pairs.
  *
- * @return vector of parsed angular-domain polygons
+ * @return parsed angular-domain polygons
+ * @throws std::runtime_error on the first unreadable group. Rejecting the whole group is
+ *         what keeps a single bad value from re-pairing the survivors into vertices that
+ *         were never written.
  */
-inline std::vector<AngularPolygon> parsePolygonsFromString(
-  const std::string & input, const rclcpp::Logger & logger)
+inline std::vector<AngularPolygon> parsePolygonsFromString(const std::string & input)
 {
   std::vector<AngularPolygon> polygons;
 
@@ -293,8 +284,9 @@ inline std::vector<AngularPolygon> parsePolygonsFromString(
   if (
     outer_start == std::string::npos || outer_end == std::string::npos ||
     outer_end <= outer_start) {
-    RCLCPP_WARN(logger, "Obstruction polygons string has invalid format.");
-    return polygons;
+    throw std::runtime_error(
+            "expected a bracketed list like \"[[az,el, az,el, az,el], ...]\", got \"" + input +
+            "\"");
   }
 
   // Parse inner polygon brackets
@@ -307,9 +299,9 @@ inline std::vector<AngularPolygon> parsePolygonsFromString(
       break;
     }
     size_t inner_end = input.find(']', inner_start);
+    const std::string poly_name_idx = "obstruction polygon " + std::to_string(poly_idx);
     if (inner_end == std::string::npos || inner_end > outer_end) {
-      RCLCPP_WARN(logger, "Obstruction polygons string has unmatched brackets.");
-      break;
+      throw std::runtime_error(poly_name_idx + " has an unmatched '['");
     }
 
     // Extract the comma-separated numbers between inner brackets
@@ -326,26 +318,29 @@ inline std::vector<AngularPolygon> parsePolygonsFromString(
       try {
         values.push_back(std::stod(token.substr(start)));
       } catch (const std::exception &) {
-        RCLCPP_WARN(
-          logger, "Obstruction polygon %d: failed to parse value '%s'.", poly_idx, token.c_str());
+        throw std::runtime_error(poly_name_idx + " has unreadable value '" + token + "'");
       }
     }
 
-    if (values.size() >= 6 && values.size() % 2 == 0) {
-      AngularPolygon vertices;
-      vertices.reserve(values.size() / 2);
-      for (size_t i = 0; i < values.size(); i += 2) {
-        vertices.push_back({values[i], values[i + 1]});
-      }
-      polygons.push_back(std::move(vertices));
-    } else if (!values.empty()) {
-      RCLCPP_WARN(
-        logger, "Obstruction polygon %d needs >= 6 values (3 x/y pairs), got %zu. Skipping.",
-        poly_idx, values.size());
+    if (values.size() < 6 || values.size() % 2 != 0) {
+      throw std::runtime_error(
+              poly_name_idx + " has " + std::to_string(values.size()) +
+              " values, needs an even count of at least 6 (3 az/el pairs)");
     }
+
+    AngularPolygon vertices;
+    vertices.reserve(values.size() / 2);
+    for (size_t i = 0; i < values.size(); i += 2) {
+      vertices.push_back({values[i], values[i + 1]});
+    }
+    polygons.push_back(std::move(vertices));
 
     poly_idx++;
     pos = inner_end + 1;
+  }
+
+  if (polygons.empty()) {
+    throw std::runtime_error("no polygons found in \"" + input + "\"");
   }
 
   return polygons;
@@ -408,22 +403,21 @@ public:
     }
     node->get_parameter(param_name, polygons_str);
 
+    // Unspecified: this sensor has no blind spots to mask, which is the common case.
     if (polygons_str.empty()) {
       return nullptr;
     }
 
-    auto raw_polygons = parsePolygonsFromString(polygons_str, logger);
-
-    if (!raw_polygons.empty()) {
-      RCLCPP_INFO(
-        logger, "Parsed %zu obstruction polygon(s) for %s", raw_polygons.size(),
-        param_prefix.c_str());
+    std::vector<ValidatedPolygon> valid_polygons;
+    try {
+      valid_polygons = validatePolygons(parsePolygonsFromString(polygons_str));
+    } catch (const std::exception & e) {
+      throw std::runtime_error("Invalid '" + param_name + "': " + e.what());
     }
 
-    auto valid_polygons = validatePolygons(raw_polygons, logger);
-    if (valid_polygons.empty()) {
-      return nullptr;
-    }
+    RCLCPP_INFO(
+      logger, "Parsed %zu obstruction polygon(s) for %s", valid_polygons.size(),
+      param_prefix.c_str());
 
     auto filter = std::make_shared<ObstructionFilter>();
     filter->flattenAndSortPolygons(valid_polygons);

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -43,7 +43,6 @@
 #include <cmath>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -142,12 +141,18 @@ public:
       const double len_sq =
         normals[i].x * normals[i].x + normals[i].y * normals[i].y + normals[i].z * normals[i].z;
 
-      constexpr double kMinEdgeNormSquared = 1e-12;
+      constexpr double kMinEdgeNormSquared = 1e-12;  // reject edges < ~1e-6 rad apart
       if (len_sq < kMinEdgeNormSquared) {
         throw std::runtime_error(
                 "has a degenerate edge between vertices " + std::to_string(i) + " and " +
                 std::to_string(j) + ": the two directions are coincident");
       }
+
+      // Normalize to ensure equal application of kConvexEps below.
+      const double len = std::sqrt(len_sq);
+      normals[i].x /= len;
+      normals[i].y /= len;
+      normals[i].z /= len;
     }
 
     // Determine orientation: centroid direction should be on inside of all half-planes
@@ -169,8 +174,11 @@ public:
       }
     }
 
-    // Verify spherical convexity. For each edge all vertices must lay on same side
-    constexpr double kConvexEps = 1e-9;  // tolerance for vertices lying on an edge's line
+    // Verify spherical convexity. For each edge all vertices must lay on same side.
+    // Normals and dirs are both unit length, so each dot product is the sine of the
+    // vertex's angular distance from that edge's plane, making this tolerance a plain
+    // angle in radians that means the same thing for every polygon.
+    constexpr double kConvexEps = 1e-9;  // radians off-plane, ~6e-8 degrees
     for (size_t i = 0; i < n; ++i) {
       for (size_t k = 0; k < n; ++k) {
         const double side =

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -419,9 +419,9 @@ public:
       logger, "Parsed %zu obstruction polygon(s) for %s", valid_polygons.size(),
       param_prefix.c_str());
 
-    auto filter = std::make_shared<ObstructionFilter>();
-    filter->flattenAndSortPolygons(valid_polygons);
-    return filter;
+    auto obstruction_filter = std::make_shared<ObstructionFilter>();
+    obstruction_filter->flattenAndSortPolygons(valid_polygons);
+    return obstruction_filter;
   }
 
 private:

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -231,19 +231,31 @@ inline std::vector<ValidatedPolygon> validatePolygons(
       continue;
     }
 
-    // Verify azimuth within bounds [0-2pi]
-    bool out_of_range = false;
+    // Verify azimuth within bounds [0-2pi] and elevation within bounds [-pi/2, pi/2].
+    bool azimuth_out_of_range = false;
+    bool elevation_out_of_range = false;
     for (const auto & v : vertices) {
       if (v.azimuth < 0.0 || v.azimuth > 2.0 * M_PI) {
-        out_of_range = true;
+        azimuth_out_of_range = true;
+        break;
+      }
+      if (v.elevation < -M_PI_2 || v.elevation > M_PI_2) {
+        elevation_out_of_range = true;
         break;
       }
     }
-    if (out_of_range) {
+    if (azimuth_out_of_range) {
       RCLCPP_WARN(
         logger,
         "Obstruction polygon %zu has vertices outside [0, 2pi] azimuth range, "
         "skipping. Polygons crossing the 0/2pi boundary are not supported.",
+        idx);
+      continue;
+    }
+    if (elevation_out_of_range) {
+      RCLCPP_WARN(
+        logger,
+        "Obstruction polygon %zu has vertices outside [-pi/2, pi/2] elevation range, skipping.",
         idx);
       continue;
     }

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/obstruction_polygons.hpp
@@ -443,6 +443,7 @@ public:
   ObstructionFilter() = default;
 
   bool empty() const { return polygons_.empty(); }
+  size_t nPolygons() const { return polygons_.size(); }
 
   /**
    * @brief Check if a 3D direction falls inside any obstruction polygon
@@ -478,32 +479,18 @@ public:
    *   obstruction_polygons: "[[x1,y1, x2,y2, x3,y3], [x4,y4, x5,y5, x6,y6]]"
    *   x=azimuth (rad), y=elevation (rad).
    */
-  template <typename NodeT>
-  static std::shared_ptr<ObstructionFilter> fromParams(
-    NodeT node, const std::string & param_prefix, const rclcpp::Logger & logger)
+  static std::shared_ptr<ObstructionFilter> fromParam(const std::string & polygons_param)
   {
-    std::string param_name = param_prefix + ".obstruction_polygons";
-    std::string polygons_str;
-    if (!node->has_parameter(param_name)) {
-      node->declare_parameter(param_name, std::string(""));
-    }
-    node->get_parameter(param_name, polygons_str);
-
-    // Unspecified: this sensor has no blind spots to mask, which is the common case.
-    if (polygons_str.empty()) {
+    if (polygons_param.empty()) {
       return nullptr;
     }
 
     std::vector<ValidatedPolygon> valid_polygons;
     try {
-      valid_polygons = validatePolygons(parsePolygonsFromString(polygons_str));
+      valid_polygons = validatePolygons(parsePolygonsFromString(polygons_param));
     } catch (const std::exception & e) {
-      throw std::runtime_error("Invalid '" + param_name + "': " + e.what());
+      throw std::runtime_error("Invalid polygon: '" + polygons_param + "'. " + e.what());
     }
-
-    RCLCPP_INFO(
-      logger, "Parsed %zu obstruction polygon(s) for %s", valid_polygons.size(),
-      param_prefix.c_str());
 
     auto obstruction_filter = std::make_shared<ObstructionFilter>();
     obstruction_filter->flattenAndSortPolygons(valid_polygons);

--- a/spatio_temporal_voxel_layer/src/frustum_models/depth_camera_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/depth_camera_frustum.cpp
@@ -315,7 +315,7 @@ void DepthCameraFrustum::SetOrientation(
   const geometry_msgs::msg::Quaternion & quat)
 /*****************************************************************************/
 {
-  _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z);
+  _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z).normalized();
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -115,16 +115,9 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
   }
 
   // Check if the point falls inside any obstruction polygon (blind spot)
-  // Regard points in blind spots as outside the frustum (i.e., not cleared)
   if (_obstruction_polygons && !_obstruction_polygons->empty()) {
-    double azimuth = std::atan2(transformed_pt[1], transformed_pt[0]);
-    if (azimuth < 0.0) {
-      azimuth += 2.0 * M_PI;  // shift to [0, 2pi] to match polygon convention
-    }
-    const double xy_dist = std::sqrt(radial_distance_squared);
-    const double elevation = std::atan2(transformed_pt[2], xy_dist);
-
-    if (geometry::isInsideAnyObstruction(*_obstruction_polygons, azimuth, elevation)) {
+    if (geometry::isInsideAnyObstruction(*_obstruction_polygons,
+        transformed_pt[0], transformed_pt[1], transformed_pt[2])) {
       return false;  // point is in a blind spot
     }
   }

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -77,8 +77,8 @@ void ThreeDimensionalLidarFrustum::TransformModel(void)
 /*****************************************************************************/
 {
   // Precompute the world->sensor transform matrices once.
-  _rotation = _orientation.conjugate().toRotationMatrix();
-  _translation = -_rotation * _position;
+  _global_to_sensor_rotation = _orientation.conjugate().toRotationMatrix();
+  _global_to_sensor_translation = -_global_to_sensor_rotation * _position;
 
   _valid_frustum = true;
 }
@@ -88,7 +88,8 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
 /*****************************************************************************/
 {
   Eigen::Vector3d point_in_global_frame(pt[0], pt[1], pt[2]);
-  Eigen::Vector3d transformed_pt = _rotation * point_in_global_frame + _translation;
+  Eigen::Vector3d transformed_pt =
+    _global_to_sensor_rotation * point_in_global_frame + _global_to_sensor_translation;
 
   const double radial_distance_squared =
     (transformed_pt[0] * transformed_pt[0]) +

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -115,9 +115,12 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
   }
 
   // Check if the point falls inside any obstruction polygon (blind spot)
-  if (_obstruction_polygons && !_obstruction_polygons->empty()) {
-    if (geometry::isInsideAnyObstruction(*_obstruction_polygons,
-        transformed_pt[0], transformed_pt[1], transformed_pt[2])) {
+  if (!_obstruction_field.empty()) {
+    if (geometry::isInsideAnyObstruction(_obstruction_field,
+        static_cast<float>(transformed_pt[0]),
+        static_cast<float>(transformed_pt[1]),
+        static_cast<float>(transformed_pt[2])))
+    {
       return false;  // point is in a blind spot
     }
   }
@@ -147,6 +150,12 @@ void ThreeDimensionalLidarFrustum::SetObstructionPolygons(
 /*****************************************************************************/
 {
   _obstruction_polygons = std::move(polygons);
+  // Build the flat SoA field used by the point-in-polygon test.
+  if (_obstruction_polygons) {
+    _obstruction_field = geometry::flattenAndSortPolygons(*_obstruction_polygons);
+  } else {
+    _obstruction_field = ObstructionField{};
+  }
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -37,6 +37,8 @@
 
 #include <spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp>
 
+#include <rclcpp/logging.hpp>
+
 namespace geometry
 {
 
@@ -112,6 +114,21 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
     }
   }
 
+  // Check if the point falls inside any obstruction polygon (blind spot)
+  // Regard points in blind spots as outside the frustum (i.e., not cleared)
+  if (_obstruction_polygons && !_obstruction_polygons->empty()) {
+    double azimuth = std::atan2(transformed_pt[1], transformed_pt[0]);
+    if (azimuth < 0.0) {
+      azimuth += 2.0 * M_PI;  // shift to [0, 2pi] to match polygon convention
+    }
+    const double xy_dist = std::sqrt(radial_distance_squared);
+    const double elevation = std::atan2(transformed_pt[2], xy_dist);
+
+    if (geometry::isInsideAnyObstruction(*_obstruction_polygons, azimuth, elevation)) {
+      return false;  // point is in a blind spot
+    }
+  }
+
   return true;
 }
 
@@ -129,6 +146,14 @@ void ThreeDimensionalLidarFrustum::SetOrientation(
 /*****************************************************************************/
 {
   _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z);
+}
+
+/*****************************************************************************/
+void ThreeDimensionalLidarFrustum::SetObstructionPolygons(
+  std::shared_ptr<std::vector<ConvexPolygon2D>> polygons)
+/*****************************************************************************/
+{
+  _obstruction_polygons = std::move(polygons);
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -123,14 +123,12 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
   }
 
   // Check if the point falls inside any obstruction polygon (blind spot)
-  if (_obstruction_filter) {
-    if (_obstruction_filter->isObstructed(
-        static_cast<float>(transformed_pt[0]),
-        static_cast<float>(transformed_pt[1]),
-        static_cast<float>(transformed_pt[2])))
-    {
-      return false;  // point is in a blind spot
-    }
+  if (_obstruction_filter && _obstruction_filter->isObstructed(
+      static_cast<float>(transformed_pt[0]),
+      static_cast<float>(transformed_pt[1]),
+      static_cast<float>(transformed_pt[2])))
+  {
+    return false;  // point is in a blind spot
   }
 
   return true;

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -115,8 +115,8 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
   }
 
   // Check if the point falls inside any obstruction polygon (blind spot)
-  if (!_obstruction_field.empty()) {
-    if (geometry::isInsideAnyObstruction(_obstruction_field,
+  if (_obstruction_filter) {
+    if (_obstruction_filter->isObstructed(
         static_cast<float>(transformed_pt[0]),
         static_cast<float>(transformed_pt[1]),
         static_cast<float>(transformed_pt[2])))
@@ -145,17 +145,11 @@ void ThreeDimensionalLidarFrustum::SetOrientation(
 }
 
 /*****************************************************************************/
-void ThreeDimensionalLidarFrustum::SetObstructionPolygons(
-  std::shared_ptr<std::vector<ConvexPolygon2D>> polygons)
+void ThreeDimensionalLidarFrustum::SetObstructionFilter(
+  std::shared_ptr<geometry::ObstructionFilter> filter)
 /*****************************************************************************/
 {
-  _obstruction_polygons = std::move(polygons);
-  // Build the flat SoA field used by the point-in-polygon test.
-  if (_obstruction_polygons) {
-    _obstruction_field = geometry::flattenAndSortPolygons(*_obstruction_polygons);
-  } else {
-    _obstruction_field = ObstructionField{};
-  }
+  _obstruction_filter = std::move(filter);
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -37,6 +37,9 @@
 
 #include <spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp>
 
+#include <memory>
+#include <utility>
+
 #include <rclcpp/logging.hpp>
 
 namespace geometry
@@ -45,9 +48,11 @@ namespace geometry
 /*****************************************************************************/
 ThreeDimensionalLidarFrustum::ThreeDimensionalLidarFrustum(
   const double & vFOV, const double & vFOVPadding, const double & hFOV,
-  const double & min_dist, const double & max_dist)
+  const double & min_dist, const double & max_dist,
+  std::shared_ptr<geometry::ObstructionFilter> obstruction_filter)
 : _vFOV(vFOV), _vFOVPadding(vFOVPadding), _hFOV(hFOV),
-  _min_d(min_dist), _max_d(max_dist)
+  _min_d(min_dist), _max_d(max_dist),
+  _obstruction_filter(std::move(obstruction_filter))
 /*****************************************************************************/
 {
   _hFOVhalf = _hFOV / 2.0;
@@ -144,14 +149,6 @@ void ThreeDimensionalLidarFrustum::SetOrientation(
 /*****************************************************************************/
 {
   _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z).normalized();
-}
-
-/*****************************************************************************/
-void ThreeDimensionalLidarFrustum::SetObstructionFilter(
-  std::shared_ptr<geometry::ObstructionFilter> filter)
-/*****************************************************************************/
-{
-  _obstruction_filter = std::move(filter);
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -71,7 +71,10 @@ ThreeDimensionalLidarFrustum::~ThreeDimensionalLidarFrustum(void)
 void ThreeDimensionalLidarFrustum::TransformModel(void)
 /*****************************************************************************/
 {
-  _orientation_conjugate = _orientation.conjugate();
+  // Precompute the world->sensor transform matrices once.
+  _rotation = _orientation.conjugate().toRotationMatrix();
+  _translation = -_rotation * _position;
+
   _valid_frustum = true;
 }
 
@@ -80,8 +83,7 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
 /*****************************************************************************/
 {
   Eigen::Vector3d point_in_global_frame(pt[0], pt[1], pt[2]);
-  Eigen::Vector3d transformed_pt =
-    _orientation_conjugate * (point_in_global_frame - _position);
+  Eigen::Vector3d transformed_pt = _rotation * point_in_global_frame + _translation;
 
   const double radial_distance_squared =
     (transformed_pt[0] * transformed_pt[0]) +
@@ -141,7 +143,7 @@ void ThreeDimensionalLidarFrustum::SetOrientation(
   const geometry_msgs::msg::Quaternion & quat)
 /*****************************************************************************/
 {
-  _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z);
+  _orientation = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z).normalized();
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -131,6 +131,7 @@ void MeasurementBuffer::BufferROSCloud(
     _observation_list.front()._clearing = _clearing;
     _observation_list.front()._marking = _marking;
     _observation_list.front()._model_type = _model_type;
+    _observation_list.front()._obstruction_polygons = _obstruction_polygons;
 
     if (_clearing && !_marking) {
       // no need to buffer points
@@ -315,6 +316,14 @@ void MeasurementBuffer::SetVerticalFovAngle(const double & vertical_fov_angle)
 /*****************************************************************************/
 {
   _vertical_fov = vertical_fov_angle;
+}
+
+/*****************************************************************************/
+void MeasurementBuffer::SetObstructionPolygons(
+  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> polygons)
+/*****************************************************************************/
+{
+  _obstruction_polygons = std::move(polygons);
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -131,7 +131,7 @@ void MeasurementBuffer::BufferROSCloud(
     _observation_list.front()._clearing = _clearing;
     _observation_list.front()._marking = _marking;
     _observation_list.front()._model_type = _model_type;
-    _observation_list.front()._obstruction_polygons = _obstruction_polygons;
+    _observation_list.front()._obstruction_filter = _obstruction_filter;
 
     if (_clearing && !_marking) {
       // no need to buffer points
@@ -319,11 +319,11 @@ void MeasurementBuffer::SetVerticalFovAngle(const double & vertical_fov_angle)
 }
 
 /*****************************************************************************/
-void MeasurementBuffer::SetObstructionPolygons(
-  std::shared_ptr<std::vector<geometry::ConvexPolygon2D>> polygons)
+void MeasurementBuffer::SetObstructionFilter(
+  std::shared_ptr<geometry::ObstructionFilter> filter)
 /*****************************************************************************/
 {
-  _obstruction_polygons = std::move(polygons);
+  _obstruction_filter = std::move(filter);
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -131,8 +131,8 @@ void SpatioTemporalVoxelGrid::ClearFrustums(
       auto * lidar_frustum = new geometry::ThreeDimensionalLidarFrustum(
         it->_vertical_fov_in_rad, it->_vertical_fov_padding_in_m,
         it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
-      if (it->_obstruction_polygons) {
-        lidar_frustum->SetObstructionPolygons(it->_obstruction_polygons);
+      if (it->_obstruction_filter) {
+        lidar_frustum->SetObstructionFilter(it->_obstruction_filter);
       }
       frustum = lidar_frustum;
     } else {

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -128,9 +128,13 @@ void SpatioTemporalVoxelGrid::ClearFrustums(
         it->_vertical_fov_in_rad,
         it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
     } else if (it->_model_type == THREE_DIMENSIONAL_LIDAR) {
-      frustum = new geometry::ThreeDimensionalLidarFrustum(
+      auto * lidar_frustum = new geometry::ThreeDimensionalLidarFrustum(
         it->_vertical_fov_in_rad, it->_vertical_fov_padding_in_m,
         it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
+      if (it->_obstruction_polygons) {
+        lidar_frustum->SetObstructionPolygons(it->_obstruction_polygons);
+      }
+      frustum = lidar_frustum;
     } else {
       // add else if statement for each implemented model
       delete frustum;

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -128,13 +128,10 @@ void SpatioTemporalVoxelGrid::ClearFrustums(
         it->_vertical_fov_in_rad,
         it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
     } else if (it->_model_type == THREE_DIMENSIONAL_LIDAR) {
-      auto * lidar_frustum = new geometry::ThreeDimensionalLidarFrustum(
+      frustum = new geometry::ThreeDimensionalLidarFrustum(
         it->_vertical_fov_in_rad, it->_vertical_fov_padding_in_m,
-        it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
-      if (it->_obstruction_filter) {
-        lidar_frustum->SetObstructionFilter(it->_obstruction_filter);
-      }
-      frustum = lidar_frustum;
+        it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m,
+        it->_obstruction_filter);
     } else {
       // add else if statement for each implemented model
       delete frustum;

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -277,16 +277,9 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     // Load obstruction polygons for 3D lidar sources
     if (model_type == THREE_DIMENSIONAL_LIDAR) {
       std::string param_prefix = name_ + "." + source;
-      auto polygons = geometry::parseObstructionPolygonsFromParams(
-        node, param_prefix, logger_);
-      if (!polygons.empty()) {
-        RCLCPP_INFO(
-          logger_,
-          "Loaded %zu obstruction polygon(s) for source '%s'",
-          polygons.size(), source.c_str());
-        _observation_buffers.back()->SetObstructionPolygons(
-          std::make_shared<std::vector<geometry::ConvexPolygon2D>>(
-            std::move(polygons)));
+      auto filter = geometry::ObstructionFilter::fromParams(node, param_prefix, logger_);
+      if (filter) {
+        _observation_buffers.back()->SetObstructionFilter(filter);
       }
     }
 

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -173,7 +173,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     double observation_keep_time, expected_update_rate, min_obstacle_height, max_obstacle_height;
     double min_z, max_z, vFOV, vFOVPadding;
     double hFOV, decay_acceleration, obstacle_range;
-    std::string topic, sensor_frame, data_type, filter_str;
+    std::string topic, sensor_frame, data_type, filter_str, obstruction_polygons;
     bool inf_is_valid = false, clearing, marking;
     bool clear_after_reading, enabled;
     int voxel_min_points;
@@ -204,6 +204,9 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     declareParameter(source + "." + "clear_after_reading", rclcpp::ParameterValue(false));
     declareParameter(source + "." + "enabled", rclcpp::ParameterValue(true));
     declareParameter(source + "." + "model_type", rclcpp::ParameterValue(0));
+    declareParameter(
+      source + "." + "obstruction_polygons",
+      rclcpp::ParameterValue(std::string("")));
 
     node->get_parameter(name_ + "." + source + "." + "topic", topic);
     node->get_parameter(name_ + "." + source + "." + "sensor_frame", sensor_frame);
@@ -245,6 +248,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     int model_type_int = 0;
     node->get_parameter(name_ + "." + source + "." + "model_type", model_type_int);
     ModelType model_type = static_cast<ModelType>(model_type_int);
+    // optional obstruction polygons string in az/el, used to persist voxels behind obstructions
+    node->get_parameter(name_ + "." + source + "." + "obstruction_polygons", obstruction_polygons);
 
     if (filter_str == "passthrough") {
       RCLCPP_INFO(logger_, "Passthough filter activated.");
@@ -276,10 +281,14 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
 
     // Load obstruction polygons for 3D lidar sources
     if (model_type == THREE_DIMENSIONAL_LIDAR) {
-      std::string param_prefix = name_ + "." + source;
-      auto filter = geometry::ObstructionFilter::fromParams(node, param_prefix, logger_);
-      if (filter) {
-        _observation_buffers.back()->SetObstructionFilter(filter);
+      auto obstruction_filter = geometry::ObstructionFilter::fromParam(obstruction_polygons);
+      if (obstruction_filter) {
+        RCLCPP_INFO(
+          logger_,
+          "Parsed %zu obstruction polygon(s) for %s",
+          obstruction_filter->nPolygons(),
+          source.c_str());
+        _observation_buffers.back()->SetObstructionFilter(obstruction_filter);
       }
     }
 

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp"
+#include "spatio_temporal_voxel_layer/obstruction_polygons.hpp"
 
 namespace spatio_temporal_voxel_layer
 {
@@ -272,6 +273,22 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
           decay_acceleration, marking, clearing, _voxel_size,
           filter, voxel_min_points, enabled, clear_after_reading, model_type,
           node->get_clock(), node->get_logger())));
+
+    // Load obstruction polygons for 3D lidar sources
+    if (model_type == THREE_DIMENSIONAL_LIDAR) {
+      std::string param_prefix = name_ + "." + source;
+      auto polygons = geometry::parseObstructionPolygonsFromParams(
+        node, param_prefix, logger_);
+      if (!polygons.empty()) {
+        RCLCPP_INFO(
+          logger_,
+          "Loaded %zu obstruction polygon(s) for source '%s'",
+          polygons.size(), source.c_str());
+        _observation_buffers.back()->SetObstructionPolygons(
+          std::make_shared<std::vector<geometry::ConvexPolygon2D>>(
+            std::move(polygons)));
+      }
+    }
 
     // Add buffer to marking observation buffers
     if (marking) {


### PR DESCRIPTION
## Add FOV Obstruction Polygons for 3D Lidar Frustum

### TL;DR

I introduced the option to add "obstruction polygons" to the 3D lidar frustum. This way obstructions which are part of the robot body are considered out of field of view and persist accordingly.

<img width="480" height="413" alt="lidar_fov_obstruction_stvl" src="https://github.com/user-attachments/assets/3f56995c-5405-4950-b776-3f19fb6d895b" />

_Green voxels are including obstruction polygons, white voxels are not (settings are slightly different in visualization so green and white do not correlate 1:1 in inside FOV region). It can be seen that in the old implementation the areas in obstructed FOV are cleared, while they persist in the new implementation._

Some documentation here may be outdated, check discussion below for changes and performance updates.

### Motivation

The concept that makes STVL fast is the assumption that everything inside the FOV is observed every update, therefore it can be cleared and filled with the latest observation without using expensive techniques such as raycasting. In my use case, the vehicle body often obstructed significant parts of the FOV of the 3D Lidar, invalidating the assumption. 
In my use case STVL was set up such that voxels outside of FOV persist for a few seconds. Sometimes there was an obstacle that got cleared when we drove past it and it was behind the obstruction (forklift mast), with the risk that our planner would now plan a path through the obstacle.

### Design

The user can add a list of obstruction polygons to the parameters. These polygons should be defined as a list of coordinates (azimuth elevation [rad] pairs) in lidar frame. When using the 3D Lidar frustum, these polygons will be loaded and when the frustums `isInside` method is called it will also check the obstruction polygons.

I implemented a ConvexPolygon2D class, that does precomputations on polygon normals to do efficient half plane comparisons with each point it has to process.

### Notes

* I tested using real world rosbags in jazzy. If desired I could make the PR to `ros2` branch as well.
* There were no tests in this package, i did not want to over complicate the PR by adding tests. There is a separate branch with tests https://github.com/remco-r/spatio_temporal_voxel_layer/tree/feature/obstruction_tests.
* Changes are not breaking. When no polygons are provided, the code should run as before. It also does not affect the depth camera frustum.
* I tried to make as little changes as possible to existing code and put most of the algo in a separate header.
* I have an AI assisted workflow, but checked every line of code and verified with unit tests.
* I vibe coded a python GUI to generate convex obstruction polygons from a pcd, also available in a separate branch https://github.com/remco-r/spatio_temporal_voxel_layer/tree/feature/obstruction_tests.

<img width="1207" height="741" alt="fov_boundary_tool_" src="https://github.com/user-attachments/assets/778c88a5-4c1c-460a-90d9-739581fbe3ab" />


### Changes

**Core feature `obstruction_polygons.hpp` (header-only)**
- `ConvexPolygon2D` struct with precomputed half-plane normals for O(n) point-in-polygon test
- Automatic winding order detection (CCW/CW) with correct inward normal computation
- `parsePolygonsFromString()` parses footprint-style bracket format: `"[[az1,el1, az2,el2, ...], [...]]"`
- `validatePolygons()` rejects degenerate, NaN, or out-of-range polygons with warnings
- `parseObstructionPolygonsFromParams()` declares and reads the ROS2 parameter

**Integration into STVL pipeline**
- `ThreeDimensionalLidarFrustum::IsInside()` after the existing hFOV check, computes azimuth/elevation and tests against obstruction polygons; points inside an obstruction polygon are not cleared
- `MeasurementBuffer` / `SpatioTemporalVoxelLayer` propagates polygons from parameter to frustum instances

**Configuration**
```yaml
observation_sources: source1
source1:
  # ... existing params ...
  obstruction_polygons: "[[az1,el1, az2,el2, az3,el3], [az4,el4, az5,el5, az6,el6]]"
```
Coordinates are in radians: azimuth [0, 2π], elevation [-π/2, π/2].

**GUI Tool `fov_boundary_tool` (Python/PyQt5) (outside of this PR)**
- Loads organized point clouds (ROS topic or PCD file), displays as range image
- User draws polygonal regions by clicking vertices on the range image
- Automatically decomposes concave selections into convex polygons
- Exports YAML and prints the STVL-compatible parameter string

### Limitations

- Polygons must be convex (the GUI tool handles decomposition)
- Does not support polygons crossing the 0/2π azimuth boundary (will check and reject)
