### PR TITLE
Add configurable 3D lidar frustum orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,25 @@ rgbd_obstacle_layer:
     vertical_fov_angle: 0.7      #default 0.7, radians
     vertical_fov_offset: 0.0     # default 0, radians. 3D Lidar only. Offset from planar axis. f.e. MID360 has a vFOV of -7deg to 52deg => offset +22.5deg (0.3927 rad)
     horizontal_fov_angle: 1.04   #default 1.04, radians
+    frustum_roll: 0.0            #default 0, radians. 3D Lidar only
+    frustum_pitch: 0.0           #default 0, radians. 3D Lidar only
+    frustum_yaw: 0.0             #default 0, radians. 3D Lidar only
     decay_acceleration: 1.       #default 0, 1/s^2. If laser scanner MUST be 0
     model_type: 0                #default 0 (depth camera). Use 1 for 3D Lidar
 ```
 More configuration samples are included in the example folder, including a 3D lidar one.
+
+For a partial 3D lidar horizontal FOV, the default forward direction is the sensor
+frame's positive X axis. The `frustum_roll`, `frustum_pitch`, and `frustum_yaw`
+parameters rotate the complete lidar frustum relative to the sensor frame using
+fixed-axis roll, pitch, and yaw angles in radians. For example, set
+`frustum_yaw: 1.57079632679` to point the center of the horizontal FOV along the
+sensor frame's positive Y axis. A yaw of `0.78539816339` points it halfway between
+positive X and positive Y. Pitch can be used when the desired direction also has a
+vertical component. The zero defaults preserve the original positive-X behavior.
+These parameters have no observable effect on the horizontal coverage when
+`horizontal_fov_angle` configures a full 360-degree FOV, though roll and pitch still
+rotate the vertical FOV band.
 
 ### local/global_costmap_params.yaml
 

--- a/spatio_temporal_voxel_layer/CMakeLists.txt
+++ b/spatio_temporal_voxel_layer/CMakeLists.txt
@@ -127,8 +127,13 @@ else()
 endif()
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_three_dimensional_lidar_frustum
+    test/test_three_dimensional_lidar_frustum.cpp)
+  target_link_libraries(test_three_dimensional_lidar_frustum ${library_name})
 endif()
 
 install(TARGETS ${library_name}

--- a/spatio_temporal_voxel_layer/example/vlp16_config.yaml
+++ b/spatio_temporal_voxel_layer/example/vlp16_config.yaml
@@ -43,5 +43,8 @@ global_costmap:
           vertical_fov_angle: 0.523   # default 0.7, radians. For 3D lidars it's the symmetric FOV about the planar axis.
           vertical_fov_padding: 0.05    # 3D Lidar only. Default 0, in meters 
           horizontal_fov_angle: 6.29  # 3D lidar scanners like the VLP16 have 360 deg horizontal FOV.
+          frustum_roll: 0.0            # Frustum rotation relative to the sensor frame, in radians.
+          frustum_pitch: 0.0           # Zero values retain the default sensor-frame orientation.
+          frustum_yaw: 0.0             # For partial FOVs, +1.5708 yaw makes +Y the forward direction.
           decay_acceleration: 5.0     # default 0, 1/s^2. 
           model_type: 1               # default 0, model type for frustum. 0=depth camera, 1=3d lidar like VLP16 or similar

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp
@@ -54,7 +54,9 @@ class ThreeDimensionalLidarFrustum : public Frustum
 public:
   ThreeDimensionalLidarFrustum(
     const double & vFOV, const double & vFOVOffset, const double & vFOVPadding,
-    const double & hFOV, const double & min_dist, const double & max_dist);
+    const double & hFOV, const double & min_dist, const double & max_dist,
+    const double & frustum_roll = 0.0, const double & frustum_pitch = 0.0,
+    const double & frustum_yaw = 0.0);
   virtual ~ThreeDimensionalLidarFrustum(void);
 
   // Does nothing in 3D lidar model
@@ -80,6 +82,7 @@ private:
   Eigen::Vector3d _position;
   Eigen::Quaterniond _orientation;
   Eigen::Quaterniond _orientation_conjugate;
+  Eigen::Quaterniond _frustum_orientation_conjugate;
   bool _valid_frustum;
   bool _full_hFOV;
 };

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_buffer.hpp
@@ -111,7 +111,10 @@ public:
     const bool & clear_buffer_after_reading,
     const ModelType & model_type,
     rclcpp::Clock::SharedPtr clock,
-    rclcpp::Logger logger);
+    rclcpp::Logger logger,
+    const double & frustum_roll = 0.0,
+    const double & frustum_pitch = 0.0,
+    const double & frustum_yaw = 0.0);
 
   ~MeasurementBuffer(void);
 
@@ -137,6 +140,9 @@ public:
   void SetVerticalFovPadding(const double & vertical_fov_padding);
   void SetHorizontalFovAngle(const double & horizontal_fov_angle);
   void SetVerticalFovAngle(const double & vertical_fov_angle);
+  void SetFrustumRoll(const double & frustum_roll);
+  void SetFrustumPitch(const double & frustum_pitch);
+  void SetFrustumYaw(const double & frustum_yaw);
 
   // State knoweldge if sensors are operating as expected
   bool UpdatedAtExpectedRate(void) const;
@@ -160,6 +166,7 @@ private:
   std::list<observation::MeasurementReading> _observation_list;
   double _min_obstacle_height, _max_obstacle_height, _obstacle_range, _tf_tolerance;
   double _min_z, _max_z, _vertical_fov, _vertical_fov_offset, _vertical_fov_padding, _horizontal_fov;
+  double _frustum_roll, _frustum_pitch, _frustum_yaw;
   double _decay_acceleration, _voxel_size;
   bool _marking, _clearing;
   Filters _filter;

--- a/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
+++ b/spatio_temporal_voxel_layer/include/spatio_temporal_voxel_layer/measurement_reading.h
@@ -71,7 +71,8 @@ struct MeasurementReading
     geometry_msgs::msg::Point & origin, sensor_msgs::msg::PointCloud2 cloud,
     double obstacle_range, double min_z, double max_z, double vFOV, double vFOVOffset,
     double vFOVPadding, double hFOV, double decay_acceleration, bool marking,
-    bool clearing, ModelType model_type)
+    bool clearing, ModelType model_type, double frustumRoll = 0.0,
+    double frustumPitch = 0.0, double frustumYaw = 0.0)
   /*****************************************************************************/
     : _origin(origin),
     _cloud(std::make_shared < sensor_msgs::msg::PointCloud2 > (cloud)),
@@ -82,6 +83,9 @@ struct MeasurementReading
     _vertical_fov_offset_in_rad(vFOVOffset),
     _vertical_fov_padding_in_m(vFOVPadding),
     _horizontal_fov_in_rad(hFOV),
+    _frustum_roll_in_rad(frustumRoll),
+    _frustum_pitch_in_rad(frustumPitch),
+    _frustum_yaw_in_rad(frustumYaw),
     _marking(marking),
     _clearing(clearing),
     _decay_acceleration(decay_acceleration),
@@ -110,6 +114,9 @@ struct MeasurementReading
     _vertical_fov_offset_in_rad(obs._vertical_fov_offset_in_rad),
     _vertical_fov_padding_in_m(obs._vertical_fov_padding_in_m),
     _horizontal_fov_in_rad(obs._horizontal_fov_in_rad),
+    _frustum_roll_in_rad(obs._frustum_roll_in_rad),
+    _frustum_pitch_in_rad(obs._frustum_pitch_in_rad),
+    _frustum_yaw_in_rad(obs._frustum_yaw_in_rad),
     _marking(obs._marking),
     _clearing(obs._clearing),
     _decay_acceleration(obs._decay_acceleration),
@@ -122,6 +129,9 @@ struct MeasurementReading
   std::shared_ptr < sensor_msgs::msg::PointCloud2 > _cloud;
   double _obstacle_range_in_m, _min_z_in_m, _max_z_in_m;
   double _vertical_fov_in_rad, _vertical_fov_offset_in_rad, _vertical_fov_padding_in_m, _horizontal_fov_in_rad;
+  double _frustum_roll_in_rad {0.0};
+  double _frustum_pitch_in_rad {0.0};
+  double _frustum_yaw_in_rad {0.0};
   double _marking, _clearing, _decay_acceleration;
   ModelType _model_type;
 };

--- a/spatio_temporal_voxel_layer/package.xml
+++ b/spatio_temporal_voxel_layer/package.xml
@@ -37,6 +37,7 @@
   <depend>point_cloud_transport_plugins</depend>
 
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <costmap_2d plugin="${prefix}/costmap_plugins.xml" />

--- a/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/src/frustum_models/three_dimensional_lidar_frustum.cpp
@@ -42,8 +42,9 @@ namespace geometry
 
 /*****************************************************************************/
 ThreeDimensionalLidarFrustum::ThreeDimensionalLidarFrustum(
-  const double & vFOV, const double & vFOVOffset, const double & vFOVPadding, 
-  const double & hFOV, const double & min_dist, const double & max_dist)
+  const double & vFOV, const double & vFOVOffset, const double & vFOVPadding,
+  const double & hFOV, const double & min_dist, const double & max_dist,
+  const double & frustum_roll, const double & frustum_pitch, const double & frustum_yaw)
 : _vFOV(vFOV), _vFOVOffset(vFOVOffset), _vFOVPadding(vFOVPadding),
   _hFOV(hFOV), _min_d(min_dist), _max_d(max_dist)
 /*****************************************************************************/
@@ -53,6 +54,11 @@ ThreeDimensionalLidarFrustum::ThreeDimensionalLidarFrustum(
   _tan_vFOVhalf_squared = _tan_vFOVhalf * _tan_vFOVhalf;
   _min_d_squared = _min_d * _min_d;
   _max_d_squared = _max_d * _max_d;
+  const Eigen::Quaterniond frustum_orientation =
+    Eigen::AngleAxisd(frustum_yaw, Eigen::Vector3d::UnitZ()) *
+    Eigen::AngleAxisd(frustum_pitch, Eigen::Vector3d::UnitY()) *
+    Eigen::AngleAxisd(frustum_roll, Eigen::Vector3d::UnitX());
+  _frustum_orientation_conjugate = frustum_orientation.conjugate();
   _full_hFOV = false;
   if (_hFOV > 6.27) {
     _full_hFOV = true;
@@ -78,8 +84,10 @@ bool ThreeDimensionalLidarFrustum::IsInside(const openvdb::Vec3d & pt)
 /*****************************************************************************/
 {
   Eigen::Vector3d point_in_global_frame(pt[0], pt[1], pt[2]);
-  Eigen::Vector3d transformed_pt =
+  const Eigen::Vector3d point_in_sensor_frame =
     _orientation_conjugate * (point_in_global_frame - _position);
+  const Eigen::Vector3d transformed_pt =
+    _frustum_orientation_conjugate * point_in_sensor_frame;
 
   const double radial_distance_squared =
     (transformed_pt[0] * transformed_pt[0]) +

--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -61,7 +61,8 @@ MeasurementBuffer::MeasurementBuffer(
   const bool & clearing, const double & voxel_size, const Filters & filter,
   const int & voxel_min_points, const bool & enabled,
   const bool & clear_buffer_after_reading, const ModelType & model_type,
-  rclcpp::Clock::SharedPtr clock, rclcpp::Logger logger)
+  rclcpp::Clock::SharedPtr clock, rclcpp::Logger logger,
+  const double & frustum_roll, const double & frustum_pitch, const double & frustum_yaw)
 : _buffer(tf),
   _observation_keep_time(rclcpp::Duration::from_seconds(observation_keep_time)),
   _expected_update_rate(rclcpp::Duration::from_seconds(expected_update_rate)),
@@ -71,7 +72,8 @@ MeasurementBuffer::MeasurementBuffer(
   _max_obstacle_height(max_obstacle_height), _obstacle_range(obstacle_range),
   _tf_tolerance(tf_tolerance), _min_z(min_d), _max_z(max_d),
   _vertical_fov(vFOV), _vertical_fov_offset(vFOVOffset), _vertical_fov_padding(vFOVPadding),
-  _horizontal_fov(hFOV), _decay_acceleration(decay_acceleration),
+  _horizontal_fov(hFOV), _frustum_roll(frustum_roll), _frustum_pitch(frustum_pitch),
+  _frustum_yaw(frustum_yaw), _decay_acceleration(decay_acceleration),
   _voxel_size(voxel_size), _marking(marking), _clearing(clearing),
   _filter(filter), _voxel_min_points(voxel_min_points),
   _clear_buffer_after_reading(clear_buffer_after_reading),
@@ -127,6 +129,9 @@ void MeasurementBuffer::BufferROSCloud(
     _observation_list.front()._vertical_fov_offset_in_rad = _vertical_fov_offset;
     _observation_list.front()._vertical_fov_padding_in_m = _vertical_fov_padding;
     _observation_list.front()._horizontal_fov_in_rad = _horizontal_fov;
+    _observation_list.front()._frustum_roll_in_rad = _frustum_roll;
+    _observation_list.front()._frustum_pitch_in_rad = _frustum_pitch;
+    _observation_list.front()._frustum_yaw_in_rad = _frustum_yaw;
     _observation_list.front()._decay_acceleration = _decay_acceleration;
     _observation_list.front()._clearing = _clearing;
     _observation_list.front()._marking = _marking;
@@ -336,6 +341,27 @@ void MeasurementBuffer::SetHorizontalFovAngle(const double & horizontal_fov_angl
 /*****************************************************************************/
 {
   _horizontal_fov = horizontal_fov_angle;
+}
+
+/*****************************************************************************/
+void MeasurementBuffer::SetFrustumRoll(const double & frustum_roll)
+/*****************************************************************************/
+{
+  _frustum_roll = frustum_roll;
+}
+
+/*****************************************************************************/
+void MeasurementBuffer::SetFrustumPitch(const double & frustum_pitch)
+/*****************************************************************************/
+{
+  _frustum_pitch = frustum_pitch;
+}
+
+/*****************************************************************************/
+void MeasurementBuffer::SetFrustumYaw(const double & frustum_yaw)
+/*****************************************************************************/
+{
+  _frustum_yaw = frustum_yaw;
 }
 
 /*****************************************************************************/

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_grid.cpp
@@ -132,7 +132,8 @@ void SpatioTemporalVoxelGrid::ClearFrustums(
     } else if (it->_model_type == THREE_DIMENSIONAL_LIDAR) {
       frustum = new geometry::ThreeDimensionalLidarFrustum(
         it->_vertical_fov_in_rad, it->_vertical_fov_offset_in_rad, it->_vertical_fov_padding_in_m,
-        it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m);
+        it->_horizontal_fov_in_rad, it->_min_z_in_m, it->_max_z_in_m,
+        it->_frustum_roll_in_rad, it->_frustum_pitch_in_rad, it->_frustum_yaw_in_rad);
     } else {
       // add else if statement for each implemented model
       delete frustum;

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -172,7 +172,8 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     // get the parameters for the specific topic
     double observation_keep_time, expected_update_rate, min_obstacle_height, max_obstacle_height;
     double min_z, max_z, vFOV, vFOVOffset, vFOVPadding;
-    double hFOV, decay_acceleration, obstacle_range;
+    double hFOV, frustumRoll, frustumPitch, frustumYaw;
+    double decay_acceleration, obstacle_range;
     std::string topic, sensor_frame, data_type, filter_str, transport_type;
     bool inf_is_valid = false, clearing, marking;
     bool clear_after_reading, enabled;
@@ -222,6 +223,13 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
     // horizontal FOV angle in rad
     hFOV = node->declare_or_get_parameter(
       name_ + "." + source + "." + "horizontal_fov_angle", 1.04);
+    // rotation of the 3D lidar frustum relative to the sensor frame, in radians
+    frustumRoll = node->declare_or_get_parameter(
+      name_ + "." + source + "." + "frustum_roll", 0.0);
+    frustumPitch = node->declare_or_get_parameter(
+      name_ + "." + source + "." + "frustum_pitch", 0.0);
+    frustumYaw = node->declare_or_get_parameter(
+      name_ + "." + source + "." + "frustum_yaw", 0.0);
     // acceleration scales the model's decay in presence of readings
     decay_acceleration = node->declare_or_get_parameter(
       name_ + "." + source + "." + "decay_acceleration", 0.0);
@@ -271,7 +279,7 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
           transform_tolerance, min_z, max_z, vFOV, vFOVOffset, vFOVPadding, hFOV,
           decay_acceleration, marking, clearing, _voxel_size,
           filter, voxel_min_points, enabled, clear_after_reading, model_type,
-          node->get_clock(), node->get_logger())));
+          node->get_clock(), node->get_logger(), frustumRoll, frustumPitch, frustumYaw)));
 
     // Add buffer to marking observation buffers
     if (marking) {
@@ -912,6 +920,30 @@ SpatioTemporalVoxelLayer::dynamicParametersCallback(std::vector<rclcpp::Paramete
             if (buffer->GetSourceName() == source) {
               buffer->Lock();
               buffer->SetHorizontalFovAngle(parameter.as_double());
+              buffer->Unlock();
+            }
+          }
+        } else if (name == name_ + "." + source + "." + "frustum_roll") {
+          for (auto & buffer : _observation_buffers) {
+            if (buffer->GetSourceName() == source) {
+              buffer->Lock();
+              buffer->SetFrustumRoll(parameter.as_double());
+              buffer->Unlock();
+            }
+          }
+        } else if (name == name_ + "." + source + "." + "frustum_pitch") {
+          for (auto & buffer : _observation_buffers) {
+            if (buffer->GetSourceName() == source) {
+              buffer->Lock();
+              buffer->SetFrustumPitch(parameter.as_double());
+              buffer->Unlock();
+            }
+          }
+        } else if (name == name_ + "." + source + "." + "frustum_yaw") {
+          for (auto & buffer : _observation_buffers) {
+            if (buffer->GetSourceName() == source) {
+              buffer->Lock();
+              buffer->SetFrustumYaw(parameter.as_double());
               buffer->Unlock();
             }
           }

--- a/spatio_temporal_voxel_layer/test/test_three_dimensional_lidar_frustum.cpp
+++ b/spatio_temporal_voxel_layer/test/test_three_dimensional_lidar_frustum.cpp
@@ -1,0 +1,96 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2026, Ardavan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "spatio_temporal_voxel_layer/frustum_models/three_dimensional_lidar_frustum.hpp"
+
+namespace
+{
+
+geometry_msgs::msg::Quaternion IdentityOrientation()
+{
+  geometry_msgs::msg::Quaternion orientation;
+  orientation.w = 1.0;
+  return orientation;
+}
+
+geometry::ThreeDimensionalLidarFrustum MakeFrustum(
+  const double roll = 0.0, const double pitch = 0.0, const double yaw = 0.0)
+{
+  geometry::ThreeDimensionalLidarFrustum frustum(
+    1.0, 0.0, 0.0, 1.0, 0.1, 10.0, roll, pitch, yaw);
+  geometry_msgs::msg::Point origin;
+  frustum.SetPosition(origin);
+  frustum.SetOrientation(IdentityOrientation());
+  frustum.TransformModel();
+  return frustum;
+}
+
+TEST(ThreeDimensionalLidarFrustum, DefaultsToPositiveXForward)
+{
+  auto frustum = MakeFrustum();
+
+  EXPECT_TRUE(frustum.IsInside(openvdb::Vec3d(2.0, 0.0, 0.0)));
+  EXPECT_FALSE(frustum.IsInside(openvdb::Vec3d(0.0, 2.0, 0.0)));
+  EXPECT_FALSE(frustum.IsInside(openvdb::Vec3d(-2.0, 0.0, 0.0)));
+}
+
+TEST(ThreeDimensionalLidarFrustum, YawCanSelectPositiveYForward)
+{
+  auto frustum = MakeFrustum(0.0, 0.0, 1.5707963267948966);
+
+  EXPECT_TRUE(frustum.IsInside(openvdb::Vec3d(0.0, 2.0, 0.0)));
+  EXPECT_FALSE(frustum.IsInside(openvdb::Vec3d(2.0, 0.0, 0.0)));
+}
+
+TEST(ThreeDimensionalLidarFrustum, YawCanSelectAnIntermediateDirection)
+{
+  auto frustum = MakeFrustum(0.0, 0.0, 0.7853981633974483);
+
+  EXPECT_TRUE(frustum.IsInside(openvdb::Vec3d(2.0, 2.0, 0.0)));
+  EXPECT_FALSE(frustum.IsInside(openvdb::Vec3d(2.0, -2.0, 0.0)));
+}
+
+TEST(ThreeDimensionalLidarFrustum, PitchCanSelectAThreeDimensionalDirection)
+{
+  auto frustum = MakeFrustum(0.0, -0.7853981633974483, 0.0);
+
+  EXPECT_TRUE(frustum.IsInside(openvdb::Vec3d(2.0, 0.0, 2.0)));
+  EXPECT_FALSE(frustum.IsInside(openvdb::Vec3d(2.0, 0.0, -2.0)));
+}
+
+}  // namespace


### PR DESCRIPTION
### Description:

During an internship, I used STVL with a LiDAR frame whose Y-axis pointed toward the front of the robot. Since the frustum assumes +X is forward, this inspired adding configurable roll, pitch, and yaw offsets.

This PR:
  - Preserves the existing +X-forward behavior by default
  - Supports arbitrary frustum orientation relative to the LiDAR frame
  - Adds documentation and unit tests for X, Y, intermediate, and tilted directions
  - Local geometry tests (passed)
  
PS: @SteveMacenski I've been inspired by your work and journey for the past couple of years. Just wanted to say thank you for everything you've done for the robotics community. This is my first open source contribution and I hope I get to learn a lot from this experience :)